### PR TITLE
refactor: Allocator abstraction + ObjHandle in Value

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(loxpp
     src/value.cpp 
     src/object.cpp
     src/table.cpp
+    src/simple_allocator.cpp
     src/vm.cpp 
     src/scanner.cpp 
     src/token.cpp 

--- a/src/allocator.h
+++ b/src/allocator.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "object.h"
+
+#include <cstdint>
+#include <string_view>
+
+struct ObjHandle {
+    uint32_t index;
+    ObjType type;
+    bool operator==(const ObjHandle& other) const {
+        return index == other.index && type == other.type;
+    }
+    bool operator!=(const ObjHandle& other) const { return !(*this == other); }
+};
+
+class Allocator {
+  public:
+    virtual ObjHandle makeString(std::string_view chars) = 0;
+    virtual Obj* deref(ObjHandle handle) const = 0;
+    virtual void collect() = 0;
+    virtual ~Allocator() = default;
+};

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -4,13 +4,10 @@
 
 #define DEBUG_PRINT_CODE
 
-std::unique_ptr<Chunk> compile(const std::string& source,
-                               std::vector<std::unique_ptr<Obj>>& objects,
-                               Table* strings) {
+std::unique_ptr<Chunk> compile(const std::string& source, Allocator* alloc) {
     auto chunk = std::make_unique<Chunk>();
     auto parser = std::make_unique<Parser>(source);
-    auto compiler = std::make_unique<Compiler>(chunk.get(), parser.get(),
-                                               &objects, strings);
+    auto compiler = std::make_unique<Compiler>(chunk.get(), parser.get(), alloc);
 
     compiler->expression();
     parser->consume(TokenType::EOF_, "Expect end of expression.");
@@ -18,10 +15,8 @@ std::unique_ptr<Chunk> compile(const std::string& source,
     return chunk;
 }
 
-Compiler::Compiler(Chunk* chunk, Parser* parser,
-                   std::vector<std::unique_ptr<Obj>>* objects, Table* strings)
-    : m_currentChunk{chunk}, m_parser{parser}, m_objects{objects},
-      m_strings{strings} {}
+Compiler::Compiler(Chunk* chunk, Parser* parser, Allocator* alloc)
+    : m_currentChunk{chunk}, m_parser{parser}, m_allocator{alloc} {}
 
 void Compiler::endCompiler() {
     emitReturn();
@@ -129,9 +124,8 @@ void Compiler::number() {
 }
 
 void Compiler::string() {
-    ObjString* str =
-        makeString(*m_objects, m_parser->m_previous.lexeme, m_strings);
-    emitBytes(Op::CONSTANT, makeConstant(from<Obj*>(static_cast<Obj*>(str))));
+    ObjHandle h = m_allocator->makeString(m_parser->m_previous.lexeme);
+    emitBytes(Op::CONSTANT, makeConstant(Value{h}));
 }
 
 void Compiler::emitByte(Byte byte) {

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -125,8 +125,8 @@ void Compiler::number() {
 }
 
 void Compiler::string() {
-    ObjHandle h = m_allocator->makeString(m_parser->m_previous.lexeme);
-    emitBytes(Op::CONSTANT, makeConstant(Value{h}));
+    ObjHandle handle = m_allocator->makeString(m_parser->m_previous.lexeme);
+    emitBytes(Op::CONSTANT, makeConstant(Value{handle}));
 }
 
 void Compiler::emitByte(Byte byte) {

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -7,7 +7,8 @@
 std::unique_ptr<Chunk> compile(const std::string& source, Allocator* alloc) {
     auto chunk = std::make_unique<Chunk>();
     auto parser = std::make_unique<Parser>(source);
-    auto compiler = std::make_unique<Compiler>(chunk.get(), parser.get(), alloc);
+    auto compiler =
+        std::make_unique<Compiler>(chunk.get(), parser.get(), alloc);
 
     compiler->expression();
     parser->consume(TokenType::EOF_, "Expect end of expression.");

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -1,24 +1,17 @@
 #pragma once
 
+#include "allocator.h"
 #include "chunk.h"
-#include "memory.h"
 #include "parser.h"
 
 #include <memory>
 #include <string>
-#include <vector>
 
-struct Table;
-
-std::unique_ptr<Chunk> compile(const std::string& source,
-                               std::vector<std::unique_ptr<Obj>>& objects,
-                               Table* strings = nullptr);
+std::unique_ptr<Chunk> compile(const std::string& source, Allocator* alloc);
 
 class Compiler {
   public:
-    Compiler(Chunk* chunk, Parser* parser,
-             std::vector<std::unique_ptr<Obj>>* objects,
-             Table* strings = nullptr);
+    Compiler(Chunk* chunk, Parser* parser, Allocator* alloc);
 
     Chunk* getCurrentChunk() const { return m_currentChunk; }
     void endCompiler();
@@ -41,6 +34,5 @@ class Compiler {
 
     Chunk* m_currentChunk;
     Parser* m_parser;
-    std::vector<std::unique_ptr<Obj>>* m_objects;
-    Table* m_strings;
+    Allocator* m_allocator;
 };

--- a/src/memory.h
+++ b/src/memory.h
@@ -1,16 +1,4 @@
 #pragma once
 
-#include "object.h"
-
-#include <memory>
-#include <utility>
-#include <vector>
-
-// Single allocation hook — future GC bookkeeping lives here.
-template <typename T, typename... Args>
-T* allocateObj(std::vector<std::unique_ptr<Obj>>& objects, Args&&... args) {
-    auto obj = std::make_unique<T>(std::forward<Args>(args)...);
-    T* ptr = obj.get();
-    objects.emplace_back(std::move(obj));
-    return ptr;
-}
+// memory.h: retained for potential future use (GC bookkeeping hooks).
+// allocateObj has been moved into SimpleAllocator.

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -3,36 +3,10 @@
 #include <cstdio>
 #include <string>
 
-#include "memory.h"
-#include "table.h"
-#include "value.h"
-
-ObjString* makeString(std::vector<std::unique_ptr<Obj>>& objects,
-                      std::string_view chars, Table* strings) {
-    uint32_t hash = hashString(chars);
-    if (strings) {
-        ObjString* interned = strings->findString(
-            chars.data(), static_cast<int>(chars.size()), hash);
-        if (interned)
-            return interned;
-    }
-
-    ObjString* str = allocateObj<ObjString>(objects);
-    str->type = ObjType::STRING;
-    str->chars = chars;
-    str->hash = hash;
-
-    if (strings)
-        strings->set(str, Value{Nil{}});
-
-    return str;
-}
-
 std::string stringifyObj(Obj* obj) {
     switch (obj->type) {
     case ObjType::STRING:
         return asObjString(obj)->chars;
-        // Future types (ObjFunction, ObjClass, etc.) go here.
     }
     return "<obj>";
 }

--- a/src/object.h
+++ b/src/object.h
@@ -1,9 +1,8 @@
 #pragma once
 
-#include <memory>
+#include <cstdint>
 #include <string>
 #include <string_view>
-#include <vector>
 
 enum class ObjType { STRING };
 
@@ -17,11 +16,6 @@ struct ObjString : public Obj {
     std::string chars;
     uint32_t hash{0};
 };
-
-struct Table; // Forward declaration to break circular dependency with table.h
-
-ObjString* makeString(std::vector<std::unique_ptr<Obj>>& objects,
-                      std::string_view chars, Table* strings = nullptr);
 
 std::string stringifyObj(Obj* obj);
 void printObject(Obj* obj);

--- a/src/simple_allocator.cpp
+++ b/src/simple_allocator.cpp
@@ -1,0 +1,41 @@
+#include "simple_allocator.h"
+
+#include "value.h"
+
+SimpleAllocator::~SimpleAllocator() {
+    for (Obj* obj : m_objects) {
+        delete obj;
+    }
+}
+
+ObjHandle SimpleAllocator::makeString(std::string_view chars) {
+    uint32_t hash = hashString(chars);
+
+    ObjString* interned = m_strings.findString(
+        chars.data(), static_cast<int>(chars.size()), hash);
+    if (interned) {
+        Value idxVal;
+        m_strings.get(interned, idxVal);
+        return ObjHandle{static_cast<uint32_t>(as<Number>(idxVal)),
+                         ObjType::STRING};
+    }
+
+    auto* str = new ObjString();
+    str->type = ObjType::STRING;
+    str->chars = std::string(chars);
+    str->hash = hash;
+
+    auto index = static_cast<uint32_t>(m_objects.size());
+    m_objects.push_back(static_cast<Obj*>(str));
+    m_strings.set(str, Value{static_cast<Number>(index)});
+
+    return ObjHandle{index, ObjType::STRING};
+}
+
+Obj* SimpleAllocator::deref(ObjHandle handle) const {
+    return m_objects[handle.index];
+}
+
+void SimpleAllocator::collect() {
+    // Stub: GC traversal not yet implemented.
+}

--- a/src/simple_allocator.h
+++ b/src/simple_allocator.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "allocator.h"
+#include "table.h"
+
+#include <cstddef>
+#include <vector>
+
+class SimpleAllocator : public Allocator {
+  public:
+    SimpleAllocator() = default;
+    ~SimpleAllocator() override;
+
+    ObjHandle makeString(std::string_view chars) override;
+    Obj* deref(ObjHandle handle) const override;
+    void collect() override;
+
+  private:
+    std::vector<Obj*> m_objects;
+    Table m_strings;
+    std::size_t m_bytesAllocated = 0;
+};

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -7,7 +7,7 @@ bool operator!(Value value) {
     return std::visit(overloaded{
                           [](bool val) -> bool { return !val; },
                           [](Nil) -> bool { return true; },
-                          [](Obj*) -> bool { return false; },
+                          [](ObjHandle) -> bool { return false; },
                           [](const auto&) -> bool { return false; },
                       },
                       value);
@@ -22,9 +22,33 @@ bool operator==(const Value& a, const Value& b) {
             [](bool a_val, bool b_val) -> bool { return a_val == b_val; },
             [](Number a_val, Number b_val) -> bool { return a_val == b_val; },
             [](Nil, Nil) -> bool { return true; },
-            [](Obj* a_obj, Obj* b_obj) -> bool { return a_obj == b_obj; },
+            // Interning guarantees: same content → same index → equal handles.
+            [](ObjHandle a_h, ObjHandle b_h) -> bool {
+                return a_h == b_h;
+            },
             [](const auto&, const auto&) -> bool { return false; }},
         a, b);
+}
+
+void printValue(const Value& value, const Allocator& alloc) {
+    std::printf("%s", stringify(value, alloc).c_str());
+}
+
+std::string stringify(const Value& value, const Allocator& alloc) {
+    return std::visit(
+        overloaded{
+            [](bool val) -> std::string { return val ? "true" : "false"; },
+            [](Number val) -> std::string {
+                char buf[64];
+                std::snprintf(buf, sizeof(buf), "%g", val);
+                return buf;
+            },
+            [](Nil) -> std::string { return "nil"; },
+            [&alloc](ObjHandle h) -> std::string {
+                return stringifyObj(alloc.deref(h));
+            },
+        },
+        value);
 }
 
 void printValue(const Value& value) {
@@ -36,14 +60,14 @@ std::string stringify(const Value& value) {
         overloaded{
             [](bool val) -> std::string { return val ? "true" : "false"; },
             [](Number val) -> std::string {
-                // Match Lox's %g formatting: no trailing zeros, compact
-                // exponent.
                 char buf[64];
                 std::snprintf(buf, sizeof(buf), "%g", val);
                 return buf;
             },
             [](Nil) -> std::string { return "nil"; },
-            [](Obj* obj) -> std::string { return stringifyObj(obj); },
+            [](ObjHandle h) -> std::string {
+                return "<str#" + std::to_string(h.index) + ">";
+            },
         },
         value);
 }

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -23,9 +23,7 @@ bool operator==(const Value& a, const Value& b) {
             [](Number a_val, Number b_val) -> bool { return a_val == b_val; },
             [](Nil, Nil) -> bool { return true; },
             // Interning guarantees: same content → same index → equal handles.
-            [](ObjHandle a_h, ObjHandle b_h) -> bool {
-                return a_h == b_h;
-            },
+            [](ObjHandle a_h, ObjHandle b_h) -> bool { return a_h == b_h; },
             [](const auto&, const auto&) -> bool { return false; }},
         a, b);
 }

--- a/src/value.h
+++ b/src/value.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "allocator.h"
 #include "object.h"
 
 #include <array>
@@ -8,9 +9,9 @@
 
 using Number = double;
 using Nil = std::monostate;
-// Obj* is non-owning. Lifetime guaranteed by VM's
-// std::vector<std::unique_ptr<Obj>>.
-using Value = std::variant<bool, Number, Nil, Obj*>;
+// ObjHandle is a lightweight, stable index into the Allocator's object store.
+// It does not dangle when the allocator moves/compacts objects.
+using Value = std::variant<bool, Number, Nil, ObjHandle>;
 
 template <typename T>
 bool is(const Value& value) {
@@ -29,20 +30,23 @@ Value from(const T& val) {
     return Value(val);
 }
 
-inline bool isObj(const Value& v) { return is<Obj*>(v); }
+inline bool isObj(const Value& v) { return is<ObjHandle>(v); }
 inline bool isString(const Value& v) {
-    return isObj(v) && isObjType(as<Obj*>(v), ObjType::STRING);
+    return is<ObjHandle>(v) && as<ObjHandle>(v).type == ObjType::STRING;
 }
-inline Obj* asObj(const Value& v) { return as<Obj*>(v); }
-inline ObjString* asObjString(const Value& v) {
-    return static_cast<ObjString*>(as<Obj*>(v));
+inline Obj* asObj(const Value& v, const Allocator& alloc) {
+    return alloc.deref(as<ObjHandle>(v));
 }
-inline const char* asCString(const Value& v) {
-    return asObjString(v)->chars.c_str();
+inline ObjString* asObjString(const Value& v, const Allocator& alloc) {
+    return static_cast<ObjString*>(alloc.deref(as<ObjHandle>(v)));
 }
 
 bool operator!(Value value);
 bool operator==(const Value& a, const Value& b);
+// Primary: dereferences ObjHandle via allocator for correct string output.
+std::string stringify(const Value& value, const Allocator& alloc);
+void printValue(const Value& value, const Allocator& alloc);
+// Debug/trace: ObjHandle prints as '<str#N>' without dereferencing.
 std::string stringify(const Value& value);
 void printValue(const Value& value);
 

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -12,7 +12,7 @@
 #define DEBUG_TRACE_EXECUTION
 
 InterpretResult VM::interpret(const std::string& source) {
-    auto chunk = compile(source, m_objects, &m_strings);
+    auto chunk = compile(source, m_allocator.get());
     if (chunk == nullptr) {
         return InterpretResult::COMPILE_ERROR;
     }
@@ -94,10 +94,10 @@ InterpretResult VM::run() {
         }
         case Op::ADD: {
             if (isString(peek(0)) && isString(peek(1))) {
-                std::string b = asObjString(pop())->chars;
-                std::string a = asObjString(pop())->chars;
-                ObjString* result = makeString(m_objects, a + b, &m_strings);
-                push(from<Obj*>(static_cast<Obj*>(result)));
+                auto* b_str = asObjString(pop(), *m_allocator);
+                auto* a_str = asObjString(pop(), *m_allocator);
+                ObjHandle h = m_allocator->makeString(a_str->chars + b_str->chars);
+                push(Value{h});
             } else {
                 BINARY_OP(Number, +);
             }
@@ -121,7 +121,7 @@ InterpretResult VM::run() {
         }
         case Op::RETURN: {
             m_lastResult = pop();
-            printValue(m_lastResult);
+            printValue(m_lastResult, *m_allocator);
             std::printf("\n");
             return InterpretResult::OK;
         }

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -96,7 +96,8 @@ InterpretResult VM::run() {
             if (isString(peek(0)) && isString(peek(1))) {
                 auto* b_str = asObjString(pop(), *m_allocator);
                 auto* a_str = asObjString(pop(), *m_allocator);
-                ObjHandle h = m_allocator->makeString(a_str->chars + b_str->chars);
+                ObjHandle h =
+                    m_allocator->makeString(a_str->chars + b_str->chars);
                 push(Value{h});
             } else {
                 BINARY_OP(Number, +);

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -96,9 +96,13 @@ InterpretResult VM::run() {
             if (isString(peek(0)) && isString(peek(1))) {
                 auto* b_str = asObjString(pop(), *m_allocator);
                 auto* a_str = asObjString(pop(), *m_allocator);
-                ObjHandle h =
+                // std::string operator+ allocates a temporary; acceptable for
+                // now. TODO: consider pre-sizing a buffer and using append() or
+                // reserve()+memcpy() to match the book's single-allocation
+                // approach.
+                ObjHandle handle =
                     m_allocator->makeString(a_str->chars + b_str->chars);
-                push(Value{h});
+                push(Value{handle});
             } else {
                 BINARY_OP(Number, +);
             }

--- a/src/vm.h
+++ b/src/vm.h
@@ -1,12 +1,11 @@
 #pragma once
 
+#include "allocator.h"
 #include "chunk.h"
-#include "object.h"
-#include "table.h"
+#include "simple_allocator.h"
 
 #include <memory>
 #include <string>
-#include <vector>
 
 enum class InterpretResult {
     OK,
@@ -18,12 +17,12 @@ class VM {
   public:
     static constexpr int STACK_MAX = 256;
 
-    VM() { resetStack(); }
+    VM() : m_allocator{std::make_unique<SimpleAllocator>()} { resetStack(); }
 
     InterpretResult interpret(const std::string& source);
     InterpretResult run();
-    Value
-    lastResult() const; // Returns the last value on the stack after execution
+    Value lastResult() const;
+    Allocator& allocator() { return *m_allocator; }
 
   private:
     Byte readByte();
@@ -39,8 +38,6 @@ class VM {
     Chunk::const_iterator m_ip;
     Value stack[STACK_MAX];
     Value* stackTop;
-    std::vector<std::unique_ptr<Obj>> m_objects;
-    Table m_strings;
-    Value m_lastResult; // For testing/debugging only — stores the value popped
-                        // by Op::RETURN.
+    std::unique_ptr<Allocator> m_allocator;
+    Value m_lastResult;
 };

--- a/src/vm.h
+++ b/src/vm.h
@@ -39,5 +39,6 @@ class VM {
     Value stack[STACK_MAX];
     Value* stackTop;
     std::unique_ptr<Allocator> m_allocator;
-    Value m_lastResult;
+    Value m_lastResult; // For testing/debugging only — stores the value popped
+                        // by Op::RETURN.
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,24 +1,48 @@
 find_package(GTest REQUIRED)
 
+set(ALLOC_SRCS
+    ${PROJECT_SOURCE_DIR}/src/simple_allocator.cpp
+    ${PROJECT_SOURCE_DIR}/src/object.cpp
+    ${PROJECT_SOURCE_DIR}/src/table.cpp
+    ${PROJECT_SOURCE_DIR}/src/value.cpp
+)
+
+set(FULL_SRCS
+    ${PROJECT_SOURCE_DIR}/src/vm.cpp
+    ${PROJECT_SOURCE_DIR}/src/compiler.cpp
+    ${PROJECT_SOURCE_DIR}/src/parser.cpp
+    ${PROJECT_SOURCE_DIR}/src/chunk.cpp
+    ${PROJECT_SOURCE_DIR}/src/value.cpp
+    ${PROJECT_SOURCE_DIR}/src/object.cpp
+    ${PROJECT_SOURCE_DIR}/src/table.cpp
+    ${PROJECT_SOURCE_DIR}/src/simple_allocator.cpp
+    ${PROJECT_SOURCE_DIR}/src/token.cpp
+    ${PROJECT_SOURCE_DIR}/src/scanner.cpp
+)
+
 add_executable(test_main test_main.cpp)
 add_executable(test_scanner test_scanner.cpp ${PROJECT_SOURCE_DIR}/src/scanner.cpp ${PROJECT_SOURCE_DIR}/src/token.cpp)
-add_executable(test_parser_vm test_parser_vm.cpp test_harness.cpp ${PROJECT_SOURCE_DIR}/src/vm.cpp ${PROJECT_SOURCE_DIR}/src/compiler.cpp ${PROJECT_SOURCE_DIR}/src/parser.cpp ${PROJECT_SOURCE_DIR}/src/chunk.cpp ${PROJECT_SOURCE_DIR}/src/value.cpp ${PROJECT_SOURCE_DIR}/src/object.cpp ${PROJECT_SOURCE_DIR}/src/table.cpp ${PROJECT_SOURCE_DIR}/src/token.cpp ${PROJECT_SOURCE_DIR}/src/scanner.cpp)
-add_executable(test_parser_bytecode test_parser_bytecode.cpp test_harness.cpp ${PROJECT_SOURCE_DIR}/src/vm.cpp ${PROJECT_SOURCE_DIR}/src/compiler.cpp ${PROJECT_SOURCE_DIR}/src/parser.cpp ${PROJECT_SOURCE_DIR}/src/chunk.cpp ${PROJECT_SOURCE_DIR}/src/value.cpp ${PROJECT_SOURCE_DIR}/src/object.cpp ${PROJECT_SOURCE_DIR}/src/table.cpp ${PROJECT_SOURCE_DIR}/src/token.cpp ${PROJECT_SOURCE_DIR}/src/scanner.cpp)
-add_executable(test_table test_table.cpp ${PROJECT_SOURCE_DIR}/src/table.cpp ${PROJECT_SOURCE_DIR}/src/object.cpp ${PROJECT_SOURCE_DIR}/src/value.cpp)
+add_executable(test_parser_vm test_parser_vm.cpp test_harness.cpp ${FULL_SRCS})
+add_executable(test_parser_bytecode test_parser_bytecode.cpp test_harness.cpp ${FULL_SRCS})
+add_executable(test_table test_table.cpp ${PROJECT_SOURCE_DIR}/src/table.cpp ${PROJECT_SOURCE_DIR}/src/object.cpp ${PROJECT_SOURCE_DIR}/src/value.cpp ${PROJECT_SOURCE_DIR}/src/simple_allocator.cpp)
+add_executable(test_allocator test_allocator.cpp ${ALLOC_SRCS})
 
 target_include_directories(test_main PRIVATE ${PROJECT_SOURCE_DIR}/src)
 target_include_directories(test_scanner PRIVATE ${PROJECT_SOURCE_DIR}/src)
 target_include_directories(test_parser_vm PRIVATE ${PROJECT_SOURCE_DIR}/src)
 target_include_directories(test_parser_bytecode PRIVATE ${PROJECT_SOURCE_DIR}/src)
 target_include_directories(test_table PRIVATE ${PROJECT_SOURCE_DIR}/src)
+target_include_directories(test_allocator PRIVATE ${PROJECT_SOURCE_DIR}/src)
 
 target_link_libraries(test_scanner PRIVATE GTest::GTest GTest::Main)
 target_link_libraries(test_parser_vm PRIVATE GTest::GTest GTest::Main)
 target_link_libraries(test_parser_bytecode PRIVATE GTest::GTest GTest::Main)
 target_link_libraries(test_table PRIVATE GTest::GTest GTest::Main)
+target_link_libraries(test_allocator PRIVATE GTest::GTest GTest::Main)
 
 add_test(NAME TestMain COMMAND test_main)
 add_test(NAME TestScanner COMMAND test_scanner)
 add_test(NAME TestParserVM COMMAND test_parser_vm)
 add_test(NAME TestParserBytecode COMMAND test_parser_bytecode)
 add_test(NAME TestTable COMMAND test_table)
+add_test(NAME TestAllocator COMMAND test_allocator)

--- a/test/test_allocator.cpp
+++ b/test/test_allocator.cpp
@@ -1,0 +1,106 @@
+#include "allocator.h"
+#include "simple_allocator.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+class AllocatorTest : public ::testing::Test {
+  protected:
+    std::unique_ptr<Allocator> alloc;
+
+    void SetUp() override { alloc = std::make_unique<SimpleAllocator>(); }
+};
+
+// ---------------------------------------------------------------------------
+// Phase 1 — Allocator interface + SimpleAllocator
+// ---------------------------------------------------------------------------
+
+TEST_F(AllocatorTest, MakeStringReturnsStringHandle) {
+    ObjHandle h = alloc->makeString("hello");
+    EXPECT_EQ(h.type, ObjType::STRING);
+}
+
+TEST_F(AllocatorTest, DerefReturnsCorrectChars) {
+    ObjHandle h = alloc->makeString("hello");
+    auto* str = static_cast<ObjString*>(alloc->deref(h));
+    EXPECT_EQ(str->chars, "hello");
+}
+
+TEST_F(AllocatorTest, MakeString_EmptyString) {
+    ObjHandle h = alloc->makeString("");
+    auto* str = static_cast<ObjString*>(alloc->deref(h));
+    EXPECT_EQ(str->chars, "");
+}
+
+TEST_F(AllocatorTest, Interning_SameContent_SameHandle) {
+    ObjHandle h1 = alloc->makeString("x");
+    ObjHandle h2 = alloc->makeString("x");
+    EXPECT_EQ(h1, h2);
+}
+
+TEST_F(AllocatorTest, Interning_DifferentContent_DifferentHandle) {
+    ObjHandle h1 = alloc->makeString("a");
+    ObjHandle h2 = alloc->makeString("b");
+    EXPECT_NE(h1, h2);
+}
+
+TEST_F(AllocatorTest, HandleStability_AfterMoreAllocations) {
+    ObjHandle h1 = alloc->makeString("first");
+    ObjHandle h2 = alloc->makeString("second");
+    ObjHandle h3 = alloc->makeString("third");
+
+    EXPECT_EQ(static_cast<ObjString*>(alloc->deref(h1))->chars, "first");
+    EXPECT_EQ(static_cast<ObjString*>(alloc->deref(h2))->chars, "second");
+    EXPECT_EQ(static_cast<ObjString*>(alloc->deref(h3))->chars, "third");
+}
+
+TEST_F(AllocatorTest, PolymorphicUsage_ViaInterfacePointer) {
+    std::unique_ptr<Allocator> a = std::make_unique<SimpleAllocator>();
+    ObjHandle h = a->makeString("poly");
+    auto* str = static_cast<ObjString*>(a->deref(h));
+    EXPECT_EQ(str->chars, "poly");
+}
+
+TEST_F(AllocatorTest, Collect_DoesNotCrash) {
+    alloc->makeString("gc1");
+    alloc->makeString("gc2");
+    alloc->makeString("gc3");
+    EXPECT_NO_FATAL_FAILURE(alloc->collect());
+}
+
+
+// ---------------------------------------------------------------------------
+// Phase 2 — ObjHandle in Value
+// ---------------------------------------------------------------------------
+
+TEST_F(AllocatorTest, ValueHoldsObjHandle) {
+    Value v{alloc->makeString("hi")};
+    EXPECT_TRUE(is<ObjHandle>(v));
+}
+
+TEST_F(AllocatorTest, IsString_TrueForStringHandle) {
+    Value vStr{alloc->makeString("hello")};
+    Value vNum{42.0};
+    Value vNil{Nil{}};
+    EXPECT_TRUE(isString(vStr));
+    EXPECT_FALSE(isString(vNum));
+    EXPECT_FALSE(isString(vNil));
+}
+
+TEST_F(AllocatorTest, Stringify_ViaAllocator) {
+    Value v{alloc->makeString("hi")};
+    EXPECT_EQ(stringify(v, *alloc), "hi");
+}
+
+TEST_F(AllocatorTest, EqualHandles_SameInternedString) {
+    Value a{alloc->makeString("x")};
+    Value b{alloc->makeString("x")};
+    EXPECT_EQ(a, b);
+}
+
+TEST_F(AllocatorTest, UnequalHandles_DifferentStrings) {
+    Value a{alloc->makeString("x")};
+    Value b{alloc->makeString("y")};
+    EXPECT_NE(a, b);
+}

--- a/test/test_allocator.cpp
+++ b/test/test_allocator.cpp
@@ -69,7 +69,6 @@ TEST_F(AllocatorTest, Collect_DoesNotCrash) {
     EXPECT_NO_FATAL_FAILURE(alloc->collect());
 }
 
-
 // ---------------------------------------------------------------------------
 // Phase 2 — ObjHandle in Value
 // ---------------------------------------------------------------------------

--- a/test/test_harness.cpp
+++ b/test/test_harness.cpp
@@ -26,6 +26,8 @@ std::string compile_to_bytecode(const std::string& expr) {
     if (!chunk)
         throw std::runtime_error("Compilation failed");
     std::ostringstream oss;
+    // TODO: implement a proper disassembler and reuse it here instead of this
+    // ad-hoc switch.
     for (size_t offset = 0; offset < chunk->size();) {
         Op op = toOpcode(chunk->at(offset));
         oss << offset << ": ";

--- a/test/test_harness.cpp
+++ b/test/test_harness.cpp
@@ -1,6 +1,7 @@
 #include "test_harness.h"
 #include "vm.h"
 #include "compiler.h"
+#include "simple_allocator.h"
 #include <sstream>
 
 Value eval_expr(const std::string& expr) {
@@ -16,18 +17,15 @@ std::string eval_expr_str(const std::string& expr) {
     if (vm.interpret(expr) != InterpretResult::OK) {
         throw std::runtime_error("Interpretation failed");
     }
-    // Convert while vm (and its owned objects) is still alive.
-    return stringify(vm.lastResult());
+    return stringify(vm.lastResult(), vm.allocator());
 }
 
 std::string compile_to_bytecode(const std::string& expr) {
-    std::vector<std::unique_ptr<Obj>> objects;
-    auto chunk = compile(expr, objects);
+    SimpleAllocator allocator;
+    auto chunk = compile(expr, &allocator);
     if (!chunk)
         throw std::runtime_error("Compilation failed");
     std::ostringstream oss;
-    // Disassemble to string (redirect printf to oss)
-    // We'll reimplement a minimal disassembler here for test output
     for (size_t offset = 0; offset < chunk->size();) {
         Op op = toOpcode(chunk->at(offset));
         oss << offset << ": ";
@@ -35,7 +33,7 @@ std::string compile_to_bytecode(const std::string& expr) {
         case Op::CONSTANT: {
             uint8_t idx = chunk->at(offset + 1);
             Value v = chunk->getConstant(idx);
-            oss << "CONSTANT " << (int)idx << " ('" << stringify(v) << "')\n";
+            oss << "CONSTANT " << (int)idx << " ('" << stringify(v, allocator) << "')\n";
             offset += 2;
             break;
         }
@@ -99,3 +97,4 @@ std::string compile_to_bytecode(const std::string& expr) {
     }
     return oss.str();
 }
+

--- a/test/test_harness.cpp
+++ b/test/test_harness.cpp
@@ -33,7 +33,8 @@ std::string compile_to_bytecode(const std::string& expr) {
         case Op::CONSTANT: {
             uint8_t idx = chunk->at(offset + 1);
             Value v = chunk->getConstant(idx);
-            oss << "CONSTANT " << (int)idx << " ('" << stringify(v, allocator) << "')\n";
+            oss << "CONSTANT " << (int)idx << " ('" << stringify(v, allocator)
+                << "')\n";
             offset += 2;
             break;
         }
@@ -97,4 +98,3 @@ std::string compile_to_bytecode(const std::string& expr) {
     }
     return oss.str();
 }
-

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -68,9 +68,7 @@ TEST(TableLifecycleTest, DefaultConstructedTableIsEmpty) {
     EXPECT_EQ(t.findString("anything", 8, 12345u), nullptr);
 }
 
-TEST(TableLifecycleTest, DestructorNoCrashOnEmpty) {
-    Table t;
-}
+TEST(TableLifecycleTest, DestructorNoCrashOnEmpty) { Table t; }
 
 TEST(TableLifecycleTest, DestructorNoCrashAfterInserts) {
     SimpleAllocator alloc;

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -1,47 +1,39 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
-#include <memory>
 #include <string>
 #include <vector>
 
-#include "memory.h"
 #include "object.h"
+#include "simple_allocator.h"
 #include "table.h"
 #include "value.h"
 
 // Fake hash for tests: returns the first byte of the string (0 for empty).
-// Using just one byte makes it trivial to engineer collisions — any two strings
-// that start with the same character always land in the same preferred bucket,
-// regardless of table capacity.
 static uint32_t fakeHash(const char* key, int length) {
     if (length == 0)
         return 0u;
     return static_cast<uint32_t>(static_cast<unsigned char>(key[0]));
 }
 
-// ============================================================
-// Shared fixture
-// ============================================================
+static ObjString* mkstr(SimpleAllocator& alloc, const std::string& s) {
+    ObjHandle h = alloc.makeString(s);
+    auto* obj = static_cast<ObjString*>(alloc.deref(h));
+    obj->hash = fakeHash(s.c_str(), static_cast<int>(s.size()));
+    return obj;
+}
 
 class TableTest : public ::testing::Test {
   protected:
-    std::vector<std::unique_ptr<Obj>> objects;
-    Table table; // default-constructed; RAII manages lifetime
+    SimpleAllocator allocator_;
+    Table table;
 
-    ObjString* str(const std::string& s) {
-        ObjString* obj = makeString(objects, s);
-        obj->hash = fakeHash(s.c_str(), static_cast<int>(s.size()));
-        return obj;
-    }
+    ObjString* str(const std::string& s) { return mkstr(allocator_, s); }
 
-    // Both strings start with 'a', so fakeHash returns 97 for both —
-    // guaranteed collision regardless of table capacity.
     std::pair<ObjString*, ObjString*> collidingPair() {
         return {str("aardvark"), str("antelope")};
     }
 
-    // N strings all starting with 'a' — all collide via fakeHash.
     std::vector<ObjString*> collidingN(int n) {
         std::vector<ObjString*> keys;
         for (int i = 0; i < n; ++i)
@@ -55,21 +47,15 @@ class TableTest : public ::testing::Test {
 // ============================================================
 
 TEST(HashFieldTest, SameContentSameHash) {
-    std::vector<std::unique_ptr<Obj>> objects;
-    auto mkstr = [&](const std::string& s) {
-        ObjString* obj = makeString(objects, s);
-        obj->hash = fakeHash(s.c_str(), static_cast<int>(s.size()));
-        return obj;
-    };
-    ObjString* a = mkstr("hello");
-    ObjString* b = mkstr("hello");
+    SimpleAllocator alloc;
+    ObjString* a = mkstr(alloc, "hello");
+    ObjString* b = mkstr(alloc, "hello");
     EXPECT_EQ(a->hash, b->hash);
 }
 
 TEST(HashFieldTest, EmptyStringNoCrash) {
-    std::vector<std::unique_ptr<Obj>> objects;
-    ObjString* obj = makeString(objects, "");
-    obj->hash = fakeHash("", 0);
+    SimpleAllocator alloc;
+    ObjString* obj = mkstr(alloc, "");
     EXPECT_EQ(obj->hash, 0u);
 }
 
@@ -78,26 +64,22 @@ TEST(HashFieldTest, EmptyStringNoCrash) {
 // ============================================================
 
 TEST(TableLifecycleTest, DefaultConstructedTableIsEmpty) {
-    // A default-constructed Table has no entries — findString returns null.
     Table t;
     EXPECT_EQ(t.findString("anything", 8, 12345u), nullptr);
 }
 
 TEST(TableLifecycleTest, DestructorNoCrashOnEmpty) {
     Table t;
-    // destructor runs here — must not crash
 }
 
 TEST(TableLifecycleTest, DestructorNoCrashAfterInserts) {
-    std::vector<std::unique_ptr<Obj>> objects;
+    SimpleAllocator alloc;
     Table t;
     for (int i = 0; i < 20; ++i) {
         std::string s = "key" + std::to_string(i);
-        ObjString* k = makeString(objects, s);
-        k->hash = fakeHash(s.c_str(), static_cast<int>(s.size()));
+        ObjString* k = mkstr(alloc, s);
         t.set(k, Value{static_cast<double>(i)});
     }
-    // destructor runs here — ASAN should stay clean
 }
 
 // ============================================================
@@ -152,13 +134,13 @@ TEST_F(TableTest, SetNumberValue) {
     EXPECT_DOUBLE_EQ(as<double>(out), 3.14);
 }
 
-TEST_F(TableTest, SetObjPtrValue) {
+TEST_F(TableTest, SetObjHandleValue) {
     ObjString* key = str("objkey");
-    ObjString* val = str("objval");
-    table.set(key, Value{static_cast<Obj*>(val)});
+    ObjHandle valHandle = allocator_.makeString("objval");
+    table.set(key, Value{valHandle});
     Value out;
     EXPECT_TRUE(table.get(key, out));
-    EXPECT_EQ(as<Obj*>(out), static_cast<Obj*>(val));
+    EXPECT_EQ(as<ObjHandle>(out), valHandle);
 }
 
 // ============================================================
@@ -227,8 +209,6 @@ TEST_F(TableTest, DeletedKeyIsNoLongerFound) {
 }
 
 TEST_F(TableTest, DeleteDoesNotOrphanCollidingKey) {
-    // Insert two keys that land in the same bucket, delete one,
-    // the other must still be findable.
     auto [a, b] = collidingPair();
     table.set(a, Value{1.0});
     table.set(b, Value{2.0});
@@ -249,7 +229,6 @@ TEST_F(TableTest, DeleteThenReinsertSameKey) {
 }
 
 TEST_F(TableTest, DeleteSeveralFromCollisionChainRemainingStillFound) {
-    // Three-way collision: delete first two, third must still be reachable.
     auto keys = collidingN(3);
     for (size_t i = 0; i < keys.size(); ++i) {
         table.set(keys[i], Value{static_cast<double>(i)});
@@ -329,15 +308,10 @@ TEST_F(TableTest, AddAllEmptySourceLeavesDestUnchanged) {
 }
 
 TEST_F(TableTest, AddAllCopiesEntriesToEmptyDest) {
-    std::vector<std::unique_ptr<Obj>> srcObjs;
+    SimpleAllocator srcAlloc;
     Table src;
-    auto srcStr = [&](const std::string& s) {
-        ObjString* obj = makeString(srcObjs, s);
-        obj->hash = fakeHash(s.c_str(), static_cast<int>(s.size()));
-        return obj;
-    };
-    ObjString* k1 = srcStr("alpha");
-    ObjString* k2 = srcStr("beta");
+    ObjString* k1 = mkstr(srcAlloc, "alpha");
+    ObjString* k2 = mkstr(srcAlloc, "beta");
     src.set(k1, Value{1.0});
     src.set(k2, Value{2.0});
 
@@ -351,14 +325,13 @@ TEST_F(TableTest, AddAllCopiesEntriesToEmptyDest) {
 }
 
 TEST_F(TableTest, AddAllNoOverlapUnionInDest) {
-    std::vector<std::unique_ptr<Obj>> srcObjs;
+    SimpleAllocator srcAlloc;
     Table src;
 
     ObjString* destKey = str("dest_only");
     table.set(destKey, Value{9.0});
 
-    ObjString* srcKey = makeString(srcObjs, "src_only");
-    srcKey->hash = fakeHash("src_only", 8);
+    ObjString* srcKey = mkstr(srcAlloc, "src_only");
     src.set(srcKey, Value{7.0});
 
     table.addAll(src);
@@ -372,7 +345,6 @@ TEST_F(TableTest, AddAllNoOverlapUnionInDest) {
 
 TEST_F(TableTest, AddAllOverlappingKeysTakesSourceValue) {
     Table src;
-    // Use the same key pointer in both tables
     ObjString* sharedKey = str("shared");
     table.set(sharedKey, Value{1.0});
     src.set(sharedKey, Value{99.0});
@@ -385,10 +357,9 @@ TEST_F(TableTest, AddAllOverlappingKeysTakesSourceValue) {
 }
 
 TEST_F(TableTest, AddAllDoesNotMutateSource) {
-    std::vector<std::unique_ptr<Obj>> srcObjs;
+    SimpleAllocator srcAlloc;
     Table src;
-    ObjString* k = makeString(srcObjs, "orig");
-    k->hash = fakeHash("orig", 4);
+    ObjString* k = mkstr(srcAlloc, "orig");
     src.set(k, Value{5.0});
 
     table.addAll(src);
@@ -422,7 +393,6 @@ TEST_F(TableTest, FindStringPresentReturnsPointer) {
 }
 
 TEST_F(TableTest, FindStringHashCollisionDifferentContentReturnsNull) {
-    // Insert only `a`; `b` collides but is absent — must not return `a`.
     auto [a, b] = collidingPair();
     table.set(a, Value{std::monostate{}});
     EXPECT_EQ(table.findString(b->chars.c_str(),
@@ -445,14 +415,8 @@ TEST_F(TableTest, FindStringByRawCharsWithoutObjStringWrapper) {
 
 class StringInternTest : public ::testing::Test {
   protected:
-    std::vector<std::unique_ptr<Obj>> objects;
+    SimpleAllocator allocator_;
     Table internTable;
-
-    ObjString* mkstr(const std::string& s) {
-        ObjString* obj = makeString(objects, s);
-        obj->hash = fakeHash(s.c_str(), static_cast<int>(s.size()));
-        return obj;
-    }
 
     ObjString* internString(const std::string& s) {
         uint32_t h = fakeHash(s.c_str(), static_cast<int>(s.size()));
@@ -460,7 +424,7 @@ class StringInternTest : public ::testing::Test {
             internTable.findString(s.c_str(), static_cast<int>(s.size()), h);
         if (found)
             return found;
-        ObjString* obj = mkstr(s);
+        ObjString* obj = mkstr(allocator_, s);
         internTable.set(obj, Value{std::monostate{}});
         return obj;
     }


### PR DESCRIPTION
## Summary

Introduces a swappable `Allocator` abstraction and replaces raw `Obj*` in `Value` with an opaque `ObjHandle`, enabling future moving/compacting GC strategies.

## Phase 1 — Allocator abstraction

- **`src/allocator.h`**: Abstract `Allocator` interface + `ObjHandle` struct (`index` + cached `ObjType`; C++17-compatible `operator==`)
- **`src/simple_allocator.h/.cpp`**: `SimpleAllocator` owns `vector<Obj*>` and intern `Table`; `makeString` interns via hash and stores index as table value; `deref` is O(1); `collect()` is a stub; destructor deletes all objects
- Removed `makeString()` free function from `object.h/.cpp`
- Removed `allocateObj<T>()` from `memory.h`
- `compile()`/`Compiler` take `Allocator*` replacing `vector<unique_ptr<Obj>>*` + `Table*`
- `VM` owns `unique_ptr<Allocator>` and exposes `allocator()` accessor

## Phase 2 — ObjHandle in Value

- `Value` variant: `Obj*` → `ObjHandle`
- `isString()` uses cached `ObjType` in handle (no deref needed)
- `asObj()`/`asObjString()` gain `Allocator&` parameter
- `stringify`/`printValue`: primary overload takes `Allocator&`; debug overload shows `<str#N>` for handles
- `Compiler::string()` stores `ObjHandle` directly in constants
- `VM Op::ADD`: pop handles, deref for `.chars`, push new handle

## Tests

- **`test/test_allocator.cpp`**: 8 Phase 1 + 5 Phase 2 tests, all against `Allocator*` interface
- **`test/test_table.cpp`**: updated to use `SimpleAllocator`; `SetObjPtrValue` → `SetObjHandleValue`
- All 6 test suites pass (debug + release)