### PR TITLE
ci: add copilot-setup-steps workflow and cloud agent docs

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,38 @@
+name: "Copilot Setup Steps"
+
+# Run automatically when this file changes for easy validation,
+# and allow manual testing from the Actions tab.
+on:
+    workflow_dispatch:
+    push:
+        paths:
+            - .github/workflows/copilot-setup-steps.yml
+            - Dockerfile
+    pull_request:
+        paths:
+            - .github/workflows/copilot-setup-steps.yml
+            - Dockerfile
+
+jobs:
+    # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+    copilot-setup-steps:
+        runs-on: ubuntu-latest
+
+        permissions:
+            contents: read
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
+            - name: Build dev image
+              uses: docker/build-push-action@v5
+              with:
+                  context: .
+                  load: true
+                  tags: loxpp-dev:latest
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,38 @@ podman build -t loxpp-dev-env .
 
 ---
 
+## Copilot cloud agent
+
+When running as a **Copilot cloud agent** (GitHub Actions), the `loxpp-dev:latest`
+image is pre-built by `.github/workflows/copilot-setup-steps.yml` before the agent
+starts. Use `docker run` for all build, test, and lint commands — do not install the
+toolchain directly on the runner.
+
+The `Dockerfile` is the single source of truth for the dev environment. Any toolchain
+change must go there; the setup steps and CI will automatically pick it up.
+
+### Build and test (cloud agent)
+
+```bash
+# Build (debug)
+docker run --rm -v $PWD:/workspace -w /workspace loxpp-dev:latest \
+  bash -c "cmake --preset debug && cmake --build build"
+
+# Run tests
+docker run --rm -v $PWD:/workspace -w /workspace loxpp-dev:latest \
+  bash -c "ctest --test-dir build --output-on-failure"
+
+# Check formatting
+docker run --rm -v $PWD:/workspace -w /workspace loxpp-dev:latest \
+  bash -c "find src test -name '*.cpp' -o -name '*.h' | xargs clang-format --dry-run --Werror"
+
+# Run clang-tidy
+docker run --rm -v $PWD:/workspace -w /workspace loxpp-dev:latest \
+  bash -c "find src -name '*.cpp' | xargs clang-tidy -p build"
+```
+
+---
+
 ## Agent task loop
 
 Every agent task follows this loop end-to-end:


### PR DESCRIPTION
## Summary

Adds the `copilot-setup-steps` workflow so GitHub Copilot cloud agent has a ready-to-use dev environment, and documents how to use it.

## Changes

### `.github/workflows/copilot-setup-steps.yml` (new)
- Builds `loxpp-dev:latest` from the `Dockerfile` with GHA layer caching
- Also triggers on `Dockerfile` changes so the cached image stays in sync
- Copilot picks this job up automatically before starting any task

### `AGENTS.md` (updated)
- Added **Copilot cloud agent** section explaining:
  - The image is pre-built — use `docker run` for all operations
  - `Dockerfile` is the single source of truth; toolchain changes go there
  - Exact `docker run` commands for build, test, lint, and static analysis

## Design rationale
The CI workflow already uses Docker (build image → `docker run`). The setup steps follow the exact same pattern, keeping `Dockerfile` as the single source of truth across CI, local agents, and cloud agents.