### PR TITLE
feat: add print and expression statements

### DIFF
--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -83,6 +83,10 @@ int Chunk::disassembleInstruction(int offset) const {
         return simpleInstruction("Op::DIVIDE", offset);
     case Op::NOT:
         return simpleInstruction("Op::NOT", offset);
+    case Op::PRINT:
+        return simpleInstruction("Op::PRINT", offset);
+    case Op::POP:
+        return simpleInstruction("Op::POP", offset);
     default:
         std::printf("Unknown opcode %hhu\n",
                     static_cast<unsigned char>(instruction));

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -22,6 +22,8 @@ enum class Op : Byte {
     MULTIPLY,
     DIVIDE,
     NOT,
+    PRINT,
+    POP,
     RETURN,
 };
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -10,9 +10,13 @@ std::unique_ptr<Chunk> compile(const std::string& source, Allocator* alloc) {
     auto compiler =
         std::make_unique<Compiler>(chunk.get(), parser.get(), alloc);
 
-    compiler->expression();
-    parser->consume(TokenType::EOF_, "Expect end of expression.");
+    while (!parser->check(TokenType::EOF_))
+        compiler->declaration();
+
     compiler->endCompiler();
+
+    if (parser->m_hadError)
+        return nullptr;
     return chunk;
 }
 
@@ -127,6 +131,32 @@ void Compiler::number() {
 void Compiler::string() {
     ObjHandle handle = m_allocator->makeString(m_parser->m_previous.lexeme);
     emitBytes(Op::CONSTANT, makeConstant(Value{handle}));
+}
+
+void Compiler::declaration() {
+    statement();
+    if (m_parser->m_panicMode)
+        m_parser->synchronize();
+}
+
+void Compiler::statement() {
+    if (m_parser->match(TokenType::PRINT)) {
+        printStatement();
+    } else {
+        expressionStatement();
+    }
+}
+
+void Compiler::printStatement() {
+    expression();
+    m_parser->consume(TokenType::SEMICOLON, "Expect ';' after value.");
+    emitByte(Op::PRINT);
+}
+
+void Compiler::expressionStatement() {
+    expression();
+    m_parser->consume(TokenType::SEMICOLON, "Expect ';' after expression.");
+    emitByte(Op::POP);
 }
 
 void Compiler::emitByte(Byte byte) {

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -24,6 +24,11 @@ class Compiler {
     void number();
     void string();
 
+    void declaration();
+    void statement();
+    void printStatement();
+    void expressionStatement();
+
   private:
     void emitByte(Byte byte);
     void emitByte(Op op);

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -124,10 +124,16 @@ InterpretResult VM::run() {
             push(from<bool>(!pop()));
             break;
         }
-        case Op::RETURN: {
-            m_lastResult = pop();
-            printValue(m_lastResult, *m_allocator);
+        case Op::PRINT: {
+            printValue(pop(), *m_allocator);
             std::printf("\n");
+            break;
+        }
+        case Op::POP: {
+            m_lastResult = pop();
+            break;
+        }
+        case Op::RETURN: {
             return InterpretResult::OK;
         }
         }

--- a/test/test_harness.cpp
+++ b/test/test_harness.cpp
@@ -6,7 +6,7 @@
 
 Value eval_expr(const std::string& expr) {
     VM vm;
-    if (vm.interpret(expr) != InterpretResult::OK) {
+    if (vm.interpret(expr + ";") != InterpretResult::OK) {
         throw std::runtime_error("Interpretation failed");
     }
     return vm.lastResult();
@@ -14,7 +14,7 @@ Value eval_expr(const std::string& expr) {
 
 std::string eval_expr_str(const std::string& expr) {
     VM vm;
-    if (vm.interpret(expr) != InterpretResult::OK) {
+    if (vm.interpret(expr + ";") != InterpretResult::OK) {
         throw std::runtime_error("Interpretation failed");
     }
     return stringify(vm.lastResult(), vm.allocator());
@@ -22,7 +22,7 @@ std::string eval_expr_str(const std::string& expr) {
 
 std::string compile_to_bytecode(const std::string& expr) {
     SimpleAllocator allocator;
-    auto chunk = compile(expr, &allocator);
+    auto chunk = compile(expr + ";", &allocator);
     if (!chunk)
         throw std::runtime_error("Compilation failed");
     std::ostringstream oss;
@@ -86,6 +86,14 @@ std::string compile_to_bytecode(const std::string& expr) {
             break;
         case Op::NOT:
             oss << "NOT\n";
+            offset += 1;
+            break;
+        case Op::PRINT:
+            oss << "PRINT\n";
+            offset += 1;
+            break;
+        case Op::POP:
+            oss << "POP\n";
             offset += 1;
             break;
         case Op::RETURN:

--- a/test/test_parser_bytecode.cpp
+++ b/test/test_parser_bytecode.cpp
@@ -1,9 +1,5 @@
 #include "test_harness.h"
-#include "compiler.h"
-#include "simple_allocator.h"
-#include "value.h"
 #include <gtest/gtest.h>
-#include <sstream>
 
 // Helper to trim whitespace for easier bytecode string comparison
 #include <algorithm>
@@ -113,68 +109,4 @@ TEST_F(ParserBytecodeTest, NilLiteral) {
                            "1: POP\n"
                            "2: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
-}
-
-TEST_F(ParserBytecodeTest, PrintStatement_Simple) {
-    // compile_to_bytecode auto-appends ";" so we pass a full print statement
-    // but the harness would append another ";". Use raw compile for this test.
-    // Instead, verify via the bytecode of a print statement directly.
-    SimpleAllocator allocator;
-    auto chunk = compile("print 1 + 2;", &allocator);
-    ASSERT_NE(chunk, nullptr);
-    std::ostringstream oss;
-    for (size_t offset = 0; offset < chunk->size();) {
-        Op op = toOpcode(chunk->at(offset));
-        oss << offset << ": ";
-        switch (op) {
-        case Op::CONSTANT: {
-            uint8_t idx = chunk->at(offset + 1);
-            Value v = chunk->getConstant(idx);
-            oss << "CONSTANT " << (int)idx << " ('" << stringify(v, allocator)
-                << "')\n";
-            offset += 2;
-            break;
-        }
-        case Op::ADD:
-            oss << "ADD\n";
-            offset += 1;
-            break;
-        case Op::PRINT:
-            oss << "PRINT\n";
-            offset += 1;
-            break;
-        case Op::RETURN:
-            oss << "RETURN\n";
-            offset += 1;
-            break;
-        default:
-            oss << "OTHER\n";
-            offset += 1;
-            break;
-        }
-    }
-    std::string expected = "0: CONSTANT 0 ('1')\n"
-                           "2: CONSTANT 1 ('2')\n"
-                           "4: ADD\n"
-                           "5: PRINT\n"
-                           "6: RETURN\n";
-    EXPECT_EQ(trim(oss.str()), trim(expected));
-}
-
-TEST_F(ParserBytecodeTest, MultiStatement_PrintThenExpr) {
-    SimpleAllocator allocator;
-    auto chunk = compile("print 1 + 2; 3.14 * 2 * 3;", &allocator);
-    ASSERT_NE(chunk, nullptr);
-    // Verify the chunk contains both PRINT and POP opcodes
-    bool hasPrint = false, hasPop = false;
-    for (size_t offset = 0; offset < chunk->size();) {
-        Op op = toOpcode(chunk->at(offset));
-        if (op == Op::PRINT)
-            hasPrint = true;
-        if (op == Op::POP)
-            hasPop = true;
-        offset += (op == Op::CONSTANT) ? 2 : 1;
-    }
-    EXPECT_TRUE(hasPrint) << "Expected PRINT opcode in chunk";
-    EXPECT_TRUE(hasPop) << "Expected POP opcode in chunk";
 }

--- a/test/test_parser_bytecode.cpp
+++ b/test/test_parser_bytecode.cpp
@@ -1,5 +1,9 @@
 #include "test_harness.h"
+#include "compiler.h"
+#include "simple_allocator.h"
+#include "value.h"
 #include <gtest/gtest.h>
+#include <sstream>
 
 // Helper to trim whitespace for easier bytecode string comparison
 #include <algorithm>
@@ -25,7 +29,8 @@ TEST_F(ParserBytecodeTest, Arithmetic_Addition) {
     std::string expected = "0: CONSTANT 0 ('1')\n"
                            "2: CONSTANT 1 ('2')\n"
                            "4: ADD\n"
-                           "5: RETURN\n";
+                           "5: POP\n"
+                           "6: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -37,7 +42,8 @@ TEST_F(ParserBytecodeTest, Arithmetic_MultiplySubtract) {
                            "4: MULTIPLY\n"
                            "5: CONSTANT 2 ('5')\n"
                            "7: SUBTRACT\n"
-                           "8: RETURN\n";
+                           "8: POP\n"
+                           "9: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -47,7 +53,8 @@ TEST_F(ParserBytecodeTest, Comparison_Equal) {
     std::string expected = "0: CONSTANT 0 ('1')\n"
                            "2: CONSTANT 1 ('1')\n"
                            "4: EQUAL\n"
-                           "5: RETURN\n";
+                           "5: POP\n"
+                           "6: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -59,7 +66,8 @@ TEST_F(ParserBytecodeTest, Comparison_LessGreater) {
                            "4: LESS\n"
                            "5: CONSTANT 2 ('1')\n"
                            "7: GREATER\n"
-                           "8: RETURN\n";
+                           "8: POP\n"
+                           "9: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -70,7 +78,8 @@ TEST_F(ParserBytecodeTest, Boolean_TrueFalseNot) {
                            "1: NOT\n"
                            "2: TRUE\n"
                            "3: EQUAL\n"
-                           "4: RETURN\n";
+                           "4: POP\n"
+                           "5: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -80,7 +89,8 @@ TEST_F(ParserBytecodeTest, String_Concatenation) {
     std::string expected = "0: CONSTANT 0 ('foo')\n"
                            "2: CONSTANT 1 ('bar')\n"
                            "4: ADD\n"
-                           "5: RETURN\n";
+                           "5: POP\n"
+                           "6: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -91,7 +101,8 @@ TEST_F(ParserBytecodeTest, GroupingAndNegate) {
                            "2: CONSTANT 1 ('2')\n"
                            "4: ADD\n"
                            "5: NEGATE\n"
-                           "6: RETURN\n";
+                           "6: POP\n"
+                           "7: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -99,6 +110,71 @@ TEST_F(ParserBytecodeTest, NilLiteral) {
     std::string expr = "nil";
     std::string bytecode = compile_to_bytecode(expr);
     std::string expected = "0: NIL\n"
-                           "1: RETURN\n";
+                           "1: POP\n"
+                           "2: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
+}
+
+TEST_F(ParserBytecodeTest, PrintStatement_Simple) {
+    // compile_to_bytecode auto-appends ";" so we pass a full print statement
+    // but the harness would append another ";". Use raw compile for this test.
+    // Instead, verify via the bytecode of a print statement directly.
+    SimpleAllocator allocator;
+    auto chunk = compile("print 1 + 2;", &allocator);
+    ASSERT_NE(chunk, nullptr);
+    std::ostringstream oss;
+    for (size_t offset = 0; offset < chunk->size();) {
+        Op op = toOpcode(chunk->at(offset));
+        oss << offset << ": ";
+        switch (op) {
+        case Op::CONSTANT: {
+            uint8_t idx = chunk->at(offset + 1);
+            Value v = chunk->getConstant(idx);
+            oss << "CONSTANT " << (int)idx << " ('" << stringify(v, allocator)
+                << "')\n";
+            offset += 2;
+            break;
+        }
+        case Op::ADD:
+            oss << "ADD\n";
+            offset += 1;
+            break;
+        case Op::PRINT:
+            oss << "PRINT\n";
+            offset += 1;
+            break;
+        case Op::RETURN:
+            oss << "RETURN\n";
+            offset += 1;
+            break;
+        default:
+            oss << "OTHER\n";
+            offset += 1;
+            break;
+        }
+    }
+    std::string expected = "0: CONSTANT 0 ('1')\n"
+                           "2: CONSTANT 1 ('2')\n"
+                           "4: ADD\n"
+                           "5: PRINT\n"
+                           "6: RETURN\n";
+    EXPECT_EQ(trim(oss.str()), trim(expected));
+}
+
+TEST_F(ParserBytecodeTest, MultiStatement_PrintThenExpr) {
+    SimpleAllocator allocator;
+    auto chunk = compile("print 1 + 2; 3.14 * 2 * 3;", &allocator);
+    ASSERT_NE(chunk, nullptr);
+    // Verify the chunk contains both PRINT and POP opcodes
+    bool hasPrint = false, hasPop = false;
+    for (size_t offset = 0; offset < chunk->size();) {
+        Op op = toOpcode(chunk->at(offset));
+        if (op == Op::PRINT)
+            hasPrint = true;
+        if (op == Op::POP)
+            hasPop = true;
+        offset += (op == Op::CONSTANT) ? 2 : 1;
+    }
+    EXPECT_TRUE(hasPrint) << "Expected PRINT opcode in chunk";
+    EXPECT_TRUE(hasPop) << "Expected POP opcode in chunk";
 }

--- a/test/test_parser_vm.cpp
+++ b/test/test_parser_vm.cpp
@@ -1,5 +1,4 @@
 #include "test_harness.h"
-#include "vm.h"
 #include <gtest/gtest.h>
 #include <cmath>
 
@@ -291,36 +290,4 @@ TEST_F(ParserVMTest, RuntimeError_NegateNonNumber) {
     expect_runtime_error("-\"s\"");
     expect_runtime_error("-nil");
     expect_runtime_error("-true");
-}
-
-// ===========================================================================
-// Statements
-// ===========================================================================
-
-TEST_F(ParserVMTest, PrintStatement_Number) {
-    // print 1 + 2; should not crash and the VM should return OK.
-    VM vm;
-    EXPECT_EQ(vm.interpret("print 1 + 2;"), InterpretResult::OK);
-}
-
-TEST_F(ParserVMTest, PrintStatement_String) {
-    VM vm;
-    EXPECT_EQ(vm.interpret("print \"hello\";"), InterpretResult::OK);
-}
-
-TEST_F(ParserVMTest, ExpressionStatement_Discards) {
-    // An expression statement evaluates and discards; the last POP sets
-    // m_lastResult, so we can still inspect the discarded value via eval_expr.
-    expect_num("3.14 * 2", 6.28);
-}
-
-TEST_F(ParserVMTest, MultiStatement_PrintThenExpr) {
-    // Acceptance-criteria input: print 1 + 2; 3.14 * 2 * 3;
-    VM vm;
-    EXPECT_EQ(vm.interpret("print 1 + 2; 3.14 * 2 * 3;"), InterpretResult::OK);
-}
-
-TEST_F(ParserVMTest, MultiStatement_ExprThenPrint) {
-    VM vm;
-    EXPECT_EQ(vm.interpret("1 + 1; print 2 + 2;"), InterpretResult::OK);
 }

--- a/test/test_parser_vm.cpp
+++ b/test/test_parser_vm.cpp
@@ -1,4 +1,5 @@
 #include "test_harness.h"
+#include "vm.h"
 #include <gtest/gtest.h>
 #include <cmath>
 
@@ -290,4 +291,36 @@ TEST_F(ParserVMTest, RuntimeError_NegateNonNumber) {
     expect_runtime_error("-\"s\"");
     expect_runtime_error("-nil");
     expect_runtime_error("-true");
+}
+
+// ===========================================================================
+// Statements
+// ===========================================================================
+
+TEST_F(ParserVMTest, PrintStatement_Number) {
+    // print 1 + 2; should not crash and the VM should return OK.
+    VM vm;
+    EXPECT_EQ(vm.interpret("print 1 + 2;"), InterpretResult::OK);
+}
+
+TEST_F(ParserVMTest, PrintStatement_String) {
+    VM vm;
+    EXPECT_EQ(vm.interpret("print \"hello\";"), InterpretResult::OK);
+}
+
+TEST_F(ParserVMTest, ExpressionStatement_Discards) {
+    // An expression statement evaluates and discards; the last POP sets
+    // m_lastResult, so we can still inspect the discarded value via eval_expr.
+    expect_num("3.14 * 2", 6.28);
+}
+
+TEST_F(ParserVMTest, MultiStatement_PrintThenExpr) {
+    // Acceptance-criteria input: print 1 + 2; 3.14 * 2 * 3;
+    VM vm;
+    EXPECT_EQ(vm.interpret("print 1 + 2; 3.14 * 2 * 3;"), InterpretResult::OK);
+}
+
+TEST_F(ParserVMTest, MultiStatement_ExprThenPrint) {
+    VM vm;
+    EXPECT_EQ(vm.interpret("1 + 1; print 2 + 2;"), InterpretResult::OK);
 }


### PR DESCRIPTION
## Summary

Adds statement-level parsing to the compiler/VM pipeline so the REPL can handle:

```
print 1 + 2;       → prints 3
3.14 * 2 * 3;      → expression statement, result discarded
```

## Changes

### New opcodes (`chunk.h`)
- `Op::PRINT` — pop top of stack and print it
- `Op::POP` — pop top of stack and discard (expression statements)

### Compiler (`compiler.h` / `compiler.cpp`)
- Added `declaration()`, `statement()`, `printStatement()`, `expressionStatement()`
- `compile()` now loops over declarations until EOF instead of parsing one expression

### VM (`vm.cpp`)
- `Op::PRINT`: pop + print with newline
- `Op::POP`: pop + store in `m_lastResult` (for test inspection)
- `Op::RETURN`: now just exits — stack is empty after all statements

### Tests
- Test harness auto-appends `;` so all existing raw-expression tests continue to work transparently
- Updated expected bytecodes in `test_parser_bytecode` (`POP` now appears before `RETURN`)
- New bytecode tests for print statement and multi-statement programs
- New end-to-end VM tests covering the acceptance-criteria input