### PR TITLE
refactor: extract disassembler into debug.h/debug.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ include_directories(${PROJECT_SOURCE_DIR}/src)
 add_executable(loxpp 
     src/main.cpp 
     src/chunk.cpp 
+    src/debug.cpp
     src/value.cpp 
     src/object.cpp
     src/table.cpp
@@ -33,6 +34,26 @@ add_executable(loxpp
     src/compiler.cpp
     src/parser.cpp
 )
+
+# Debug output flags: default ON for Debug builds, OFF otherwise.
+string(TOUPPER "${CMAKE_BUILD_TYPE}" _build_type_upper)
+if(_build_type_upper STREQUAL "DEBUG")
+    set(_debug_default ON)
+else()
+    set(_debug_default OFF)
+endif()
+
+option(LOXPP_DEBUG_PRINT_CODE
+    "Disassemble each compiled chunk after compilation" ${_debug_default})
+option(LOXPP_DEBUG_TRACE_EXECUTION
+    "Trace VM execution: print stack + disassemble each instruction" ${_debug_default})
+
+if(LOXPP_DEBUG_PRINT_CODE)
+    target_compile_definitions(loxpp PRIVATE LOXPP_DEBUG_PRINT_CODE)
+endif()
+if(LOXPP_DEBUG_TRACE_EXECUTION)
+    target_compile_definitions(loxpp PRIVATE LOXPP_DEBUG_TRACE_EXECUTION)
+endif()
 
 enable_testing()
 add_subdirectory(test)

--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -1,21 +1,5 @@
 #include "chunk.h"
 
-#include <cstdio>
-
-static int simpleInstruction(const char* name, int offset) {
-    std::printf("%s\n", name);
-    return offset + 1;
-}
-
-static int constantInstruction(const char* name, const Chunk& chunk,
-                               int offset) {
-    auto constantIdx = chunk.at(offset + 1);
-    std::printf("%-16s %4d '", name, constantIdx);
-    printValue(chunk.getConstant(constantIdx));
-    std::printf("'\n");
-    return offset + 2;
-}
-
 void Chunk::write(Byte byte, int line) {
     push_back(byte);
 
@@ -42,64 +26,6 @@ int Chunk::getLine(int offset) const {
         }
     }
     return 0; // Error case
-}
-
-int Chunk::disassembleInstruction(int offset) const {
-    std::printf("%04d ", offset);
-
-    if (offset > 0 && getLine(offset) == getLine(offset - 1)) {
-        std::printf("   | ");
-    } else {
-        std::printf("%4d ", getLine(offset));
-    }
-
-    Op instruction = toOpcode(this->at(offset));
-    switch (instruction) {
-    case Op::RETURN:
-        return simpleInstruction("Op::RETURN", offset);
-    case Op::NEGATE:
-        return simpleInstruction("Op::NEGATE", offset);
-    case Op::CONSTANT:
-        return constantInstruction("Op::CONSTANT", *this, offset);
-    case Op::NIL:
-        return simpleInstruction("Op::NIL", offset);
-    case Op::TRUE:
-        return simpleInstruction("Op::TRUE", offset);
-    case Op::FALSE:
-        return simpleInstruction("Op::FALSE", offset);
-    case Op::EQUAL:
-        return simpleInstruction("Op::EQUAL", offset);
-    case Op::GREATER:
-        return simpleInstruction("Op::GREATER", offset);
-    case Op::LESS:
-        return simpleInstruction("Op::LESS", offset);
-    case Op::ADD:
-        return simpleInstruction("Op::ADD", offset);
-    case Op::SUBTRACT:
-        return simpleInstruction("Op::SUBTRACT", offset);
-    case Op::MULTIPLY:
-        return simpleInstruction("Op::MULTIPLY", offset);
-    case Op::DIVIDE:
-        return simpleInstruction("Op::DIVIDE", offset);
-    case Op::NOT:
-        return simpleInstruction("Op::NOT", offset);
-    case Op::PRINT:
-        return simpleInstruction("Op::PRINT", offset);
-    case Op::POP:
-        return simpleInstruction("Op::POP", offset);
-    default:
-        std::printf("Unknown opcode %hhu\n",
-                    static_cast<unsigned char>(instruction));
-        return offset + 1;
-    }
-}
-
-void Chunk::disassemble(const char* name) const {
-    std::printf("== %s ==\n", name);
-
-    for (int offset = 0; offset < size();) {
-        offset = disassembleInstruction(offset);
-    }
 }
 
 Value Chunk::getConstant(int idx) const { return m_constants.at(idx); }

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -41,8 +41,6 @@ class Chunk : std::vector<Byte> {
     void write(Byte byte, int line);
     void write(Op op, int line);
     uint8_t addConstant(Value value);
-    void disassemble(const char* name) const;
-    int disassembleInstruction(int offset) const;
     Value getConstant(int idx) const;
     int getLine(int offset) const;
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1,8 +1,8 @@
 #include "compiler.h"
+#include "debug.h"
 
+#include <iostream>
 #include <memory>
-
-#define DEBUG_PRINT_CODE
 
 std::unique_ptr<Chunk> compile(const std::string& source, Allocator* alloc) {
     auto chunk = std::make_unique<Chunk>();
@@ -25,8 +25,8 @@ Compiler::Compiler(Chunk* chunk, Parser* parser, Allocator* alloc)
 
 void Compiler::endCompiler() {
     emitReturn();
-#ifdef DEBUG_PRINT_CODE
-    m_currentChunk->disassemble("code");
+#ifdef LOXPP_DEBUG_PRINT_CODE
+    disassembleChunk(*m_currentChunk, *m_allocator, "code", std::cout);
 #endif
 }
 

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1,0 +1,71 @@
+#include "debug.h"
+#include "allocator.h"
+#include "value.h"
+
+#include <ostream>
+
+static int simpleInstruction(const char* name, int offset, std::ostream& out) {
+    out << name << '\n';
+    return offset + 1;
+}
+
+static int constantInstruction(const char* name, const Chunk& chunk,
+                               const Allocator& alloc, int offset,
+                               std::ostream& out) {
+    uint8_t idx = chunk.at(offset + 1);
+    out << name << ' ' << static_cast<int>(idx) << " ('"
+        << stringify(chunk.getConstant(idx), alloc) << "')\n";
+    return offset + 2;
+}
+
+void disassembleChunk(const Chunk& chunk, const Allocator& alloc,
+                      const char* name, std::ostream& out) {
+    out << "== " << name << " ==\n";
+    for (int offset = 0; offset < static_cast<int>(chunk.size());) {
+        offset = disassembleInstruction(chunk, alloc, offset, out);
+    }
+}
+
+int disassembleInstruction(const Chunk& chunk, const Allocator& alloc,
+                           int offset, std::ostream& out) {
+    out << offset << ": ";
+
+    Op instruction = toOpcode(chunk.at(offset));
+    switch (instruction) {
+    case Op::CONSTANT:
+        return constantInstruction("CONSTANT", chunk, alloc, offset, out);
+    case Op::NIL:
+        return simpleInstruction("NIL", offset, out);
+    case Op::TRUE:
+        return simpleInstruction("TRUE", offset, out);
+    case Op::FALSE:
+        return simpleInstruction("FALSE", offset, out);
+    case Op::EQUAL:
+        return simpleInstruction("EQUAL", offset, out);
+    case Op::GREATER:
+        return simpleInstruction("GREATER", offset, out);
+    case Op::LESS:
+        return simpleInstruction("LESS", offset, out);
+    case Op::NEGATE:
+        return simpleInstruction("NEGATE", offset, out);
+    case Op::ADD:
+        return simpleInstruction("ADD", offset, out);
+    case Op::SUBTRACT:
+        return simpleInstruction("SUBTRACT", offset, out);
+    case Op::MULTIPLY:
+        return simpleInstruction("MULTIPLY", offset, out);
+    case Op::DIVIDE:
+        return simpleInstruction("DIVIDE", offset, out);
+    case Op::NOT:
+        return simpleInstruction("NOT", offset, out);
+    case Op::PRINT:
+        return simpleInstruction("PRINT", offset, out);
+    case Op::POP:
+        return simpleInstruction("POP", offset, out);
+    case Op::RETURN:
+        return simpleInstruction("RETURN", offset, out);
+    default:
+        out << "UNKNOWN(" << static_cast<unsigned>(chunk.at(offset)) << ")\n";
+        return offset + 1;
+    }
+}

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "chunk.h"
+
+#include <iosfwd>
+
+class Allocator;
+
+// Disassembles an entire chunk, printing a header followed by each instruction.
+void disassembleChunk(const Chunk& chunk, const Allocator& alloc,
+                      const char* name, std::ostream& out);
+
+// Disassembles a single instruction at `offset`.
+// Returns the offset of the next instruction.
+int disassembleInstruction(const Chunk& chunk, const Allocator& alloc,
+                           int offset, std::ostream& out);

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -1,4 +1,5 @@
 #include "vm.h"
+#include "debug.h"
 #include "object.h"
 #include "scanner.h"
 #include "compiler.h"
@@ -6,10 +7,8 @@
 #include <cstdio>
 #include <cstdarg>
 #include <functional>
-#include <string>
 #include <iostream>
-
-#define DEBUG_TRACE_EXECUTION
+#include <string>
 
 InterpretResult VM::interpret(const std::string& source) {
     auto chunk = compile(source, m_allocator.get());
@@ -41,7 +40,9 @@ InterpretResult VM::run() {
     } while (false)
 
     for (;;) {
-#ifdef DEBUG_TRACE_EXECUTION
+#ifdef LOXPP_DEBUG_TRACE_EXECUTION
+        int currentOffset = static_cast<int>(m_ip - m_chunk->cbegin());
+        std::printf("[line %d] ", m_chunk->getLine(currentOffset));
         std::printf("          ");
         for (Value* slot = stack; slot < stackTop; slot++) {
             std::printf("[ ");
@@ -49,7 +50,8 @@ InterpretResult VM::run() {
             std::printf(" ]");
         }
         std::printf("\n");
-        m_chunk->disassembleInstruction(m_ip - m_chunk->cbegin());
+        disassembleInstruction(*m_chunk, *m_allocator, currentOffset,
+                               std::cout);
 #endif
 
         Byte instruction = readByte();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,7 @@ set(FULL_SRCS
     ${PROJECT_SOURCE_DIR}/src/compiler.cpp
     ${PROJECT_SOURCE_DIR}/src/parser.cpp
     ${PROJECT_SOURCE_DIR}/src/chunk.cpp
+    ${PROJECT_SOURCE_DIR}/src/debug.cpp
     ${PROJECT_SOURCE_DIR}/src/value.cpp
     ${PROJECT_SOURCE_DIR}/src/object.cpp
     ${PROJECT_SOURCE_DIR}/src/table.cpp

--- a/test/test_harness.cpp
+++ b/test/test_harness.cpp
@@ -1,6 +1,7 @@
 #include "test_harness.h"
 #include "vm.h"
 #include "compiler.h"
+#include "debug.h"
 #include "simple_allocator.h"
 #include <sstream>
 
@@ -26,85 +27,8 @@ std::string compile_to_bytecode(const std::string& expr) {
     if (!chunk)
         throw std::runtime_error("Compilation failed");
     std::ostringstream oss;
-    // TODO: implement a proper disassembler and reuse it here instead of this
-    // ad-hoc switch.
-    for (size_t offset = 0; offset < chunk->size();) {
-        Op op = toOpcode(chunk->at(offset));
-        oss << offset << ": ";
-        switch (op) {
-        case Op::CONSTANT: {
-            uint8_t idx = chunk->at(offset + 1);
-            Value v = chunk->getConstant(idx);
-            oss << "CONSTANT " << (int)idx << " ('" << stringify(v, allocator)
-                << "')\n";
-            offset += 2;
-            break;
-        }
-        case Op::NIL:
-            oss << "NIL\n";
-            offset += 1;
-            break;
-        case Op::TRUE:
-            oss << "TRUE\n";
-            offset += 1;
-            break;
-        case Op::FALSE:
-            oss << "FALSE\n";
-            offset += 1;
-            break;
-        case Op::EQUAL:
-            oss << "EQUAL\n";
-            offset += 1;
-            break;
-        case Op::GREATER:
-            oss << "GREATER\n";
-            offset += 1;
-            break;
-        case Op::LESS:
-            oss << "LESS\n";
-            offset += 1;
-            break;
-        case Op::NEGATE:
-            oss << "NEGATE\n";
-            offset += 1;
-            break;
-        case Op::ADD:
-            oss << "ADD\n";
-            offset += 1;
-            break;
-        case Op::SUBTRACT:
-            oss << "SUBTRACT\n";
-            offset += 1;
-            break;
-        case Op::MULTIPLY:
-            oss << "MULTIPLY\n";
-            offset += 1;
-            break;
-        case Op::DIVIDE:
-            oss << "DIVIDE\n";
-            offset += 1;
-            break;
-        case Op::NOT:
-            oss << "NOT\n";
-            offset += 1;
-            break;
-        case Op::PRINT:
-            oss << "PRINT\n";
-            offset += 1;
-            break;
-        case Op::POP:
-            oss << "POP\n";
-            offset += 1;
-            break;
-        case Op::RETURN:
-            oss << "RETURN\n";
-            offset += 1;
-            break;
-        default:
-            oss << "UNKNOWN\n";
-            offset += 1;
-            break;
-        }
+    for (int offset = 0; offset < static_cast<int>(chunk->size());) {
+        offset = disassembleInstruction(*chunk, allocator, offset, oss);
     }
     return oss.str();
 }


### PR DESCRIPTION
## What

Extracts the disassembler into a standalone component and eliminates duplicate ad-hoc code.

## Problem

The codebase had two disassembler implementations that diverged:
- `Chunk::disassemble` / `Chunk::disassembleInstruction` — printed to stdout via `printf`, had `Op::` prefix, zero-padded offsets, line numbers
- An ad-hoc 70-line `switch` in `test_harness.cpp` — had a TODO comment asking for a proper disassembler

Additionally, `DEBUG_PRINT_CODE` and `DEBUG_TRACE_EXECUTION` were hardcoded `#define`s — always on, not toggleable.

## Solution

### New component: `src/debug.h` / `src/debug.cpp`

Free functions (no state, no class needed):
```cpp
void disassembleChunk(const Chunk&, const Allocator&, const char* name, std::ostream&);
int  disassembleInstruction(const Chunk&, const Allocator&, int offset, std::ostream&);
```

- **`std::ostream&` interface** — callers pass `std::cout` (debug), `std::ostringstream` (tests), or anything else without heap allocation
- **`Allocator&` required** — string constants now display actual content (`'foo'`) instead of `'<str#0>'`
- **Canonical format**: `offset: OPNAME [operands]` — no `Op::` prefix, no line numbers (matches existing test expectations exactly)

### Changes

- `Chunk` loses `disassemble` and `disassembleInstruction` — it's a dumb bytecode container, not a printer
- `test_harness.cpp` drops the 70-line ad-hoc switch in favour of `disassembleInstruction`
- `compiler.cpp` and `vm.cpp` use the new functions; VM trace prints `[line N]` separately so canonical format stays clean
- `#define DEBUG_PRINT_CODE` and `#define DEBUG_TRACE_EXECUTION` replaced with CMake options `LOXPP_DEBUG_PRINT_CODE` and `LOXPP_DEBUG_TRACE_EXECUTION` (default **ON** for Debug builds, **OFF** for Release)

## Testing

All 6 tests pass. `TestParserBytecode` in particular exercises the canonical disassembler format directly.