### PR TITLE
feat: add optional ANSI color output to disassembler

### DIFF
--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include <memory>
+#include <unistd.h>
 
 std::unique_ptr<Chunk> compile(const std::string& source, Allocator* alloc) {
     auto chunk = std::make_unique<Chunk>();
@@ -26,7 +27,8 @@ Compiler::Compiler(Chunk* chunk, Parser* parser, Allocator* alloc)
 void Compiler::endCompiler() {
     emitReturn();
 #ifdef LOXPP_DEBUG_PRINT_CODE
-    disassembleChunk(*m_currentChunk, *m_allocator, "code", std::cout);
+    bool color = isatty(STDOUT_FILENO) != 0;
+    disassembleChunk(*m_currentChunk, *m_allocator, "code", std::cout, color);
 #endif
 }
 

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -4,68 +4,88 @@
 
 #include <ostream>
 
-static int simpleInstruction(const char* name, int offset, std::ostream& out) {
-    out << name << '\n';
+namespace {
+
+constexpr const char* kReset = "\033[0m";
+constexpr const char* kBold = "\033[1m";
+constexpr const char* kDim = "\033[2m";
+constexpr const char* kYellow = "\033[33m";
+constexpr const char* kRed = "\033[31m";
+
+// Returns `code` when color is enabled, otherwise "".
+inline const char* cc(bool use, const char* code) { return use ? code : ""; }
+
+} // namespace
+
+static int simpleInstruction(const char* name, int offset, std::ostream& out,
+                             bool color) {
+    out << cc(color, kBold) << name << cc(color, kReset) << '\n';
     return offset + 1;
 }
 
 static int constantInstruction(const char* name, const Chunk& chunk,
                                const Allocator& alloc, int offset,
-                               std::ostream& out) {
+                               std::ostream& out, bool color) {
     uint8_t idx = chunk.at(offset + 1);
-    out << name << ' ' << static_cast<int>(idx) << " ('"
-        << stringify(chunk.getConstant(idx), alloc) << "')\n";
+    out << cc(color, kBold) << name << cc(color, kReset) << ' '
+        << static_cast<int>(idx) << " ('" << cc(color, kYellow)
+        << stringify(chunk.getConstant(idx), alloc) << cc(color, kReset)
+        << "')\n";
     return offset + 2;
 }
 
 void disassembleChunk(const Chunk& chunk, const Allocator& alloc,
-                      const char* name, std::ostream& out) {
-    out << "== " << name << " ==\n";
+                      const char* name, std::ostream& out, bool color) {
+    out << cc(color, kBold) << "== " << name << " ==" << cc(color, kReset)
+        << '\n';
     for (int offset = 0; offset < static_cast<int>(chunk.size());) {
-        offset = disassembleInstruction(chunk, alloc, offset, out);
+        offset = disassembleInstruction(chunk, alloc, offset, out, color);
     }
 }
 
 int disassembleInstruction(const Chunk& chunk, const Allocator& alloc,
-                           int offset, std::ostream& out) {
-    out << offset << ": ";
+                           int offset, std::ostream& out, bool color) {
+    out << cc(color, kDim) << offset << ": " << cc(color, kReset);
 
     Op instruction = toOpcode(chunk.at(offset));
     switch (instruction) {
     case Op::CONSTANT:
-        return constantInstruction("CONSTANT", chunk, alloc, offset, out);
+        return constantInstruction("CONSTANT", chunk, alloc, offset, out,
+                                   color);
     case Op::NIL:
-        return simpleInstruction("NIL", offset, out);
+        return simpleInstruction("NIL", offset, out, color);
     case Op::TRUE:
-        return simpleInstruction("TRUE", offset, out);
+        return simpleInstruction("TRUE", offset, out, color);
     case Op::FALSE:
-        return simpleInstruction("FALSE", offset, out);
+        return simpleInstruction("FALSE", offset, out, color);
     case Op::EQUAL:
-        return simpleInstruction("EQUAL", offset, out);
+        return simpleInstruction("EQUAL", offset, out, color);
     case Op::GREATER:
-        return simpleInstruction("GREATER", offset, out);
+        return simpleInstruction("GREATER", offset, out, color);
     case Op::LESS:
-        return simpleInstruction("LESS", offset, out);
+        return simpleInstruction("LESS", offset, out, color);
     case Op::NEGATE:
-        return simpleInstruction("NEGATE", offset, out);
+        return simpleInstruction("NEGATE", offset, out, color);
     case Op::ADD:
-        return simpleInstruction("ADD", offset, out);
+        return simpleInstruction("ADD", offset, out, color);
     case Op::SUBTRACT:
-        return simpleInstruction("SUBTRACT", offset, out);
+        return simpleInstruction("SUBTRACT", offset, out, color);
     case Op::MULTIPLY:
-        return simpleInstruction("MULTIPLY", offset, out);
+        return simpleInstruction("MULTIPLY", offset, out, color);
     case Op::DIVIDE:
-        return simpleInstruction("DIVIDE", offset, out);
+        return simpleInstruction("DIVIDE", offset, out, color);
     case Op::NOT:
-        return simpleInstruction("NOT", offset, out);
+        return simpleInstruction("NOT", offset, out, color);
     case Op::PRINT:
-        return simpleInstruction("PRINT", offset, out);
+        return simpleInstruction("PRINT", offset, out, color);
     case Op::POP:
-        return simpleInstruction("POP", offset, out);
+        return simpleInstruction("POP", offset, out, color);
     case Op::RETURN:
-        return simpleInstruction("RETURN", offset, out);
+        return simpleInstruction("RETURN", offset, out, color);
     default:
-        out << "UNKNOWN(" << static_cast<unsigned>(chunk.at(offset)) << ")\n";
+        out << cc(color, kRed) << cc(color, kBold) << "UNKNOWN("
+            << static_cast<unsigned>(chunk.at(offset)) << ")"
+            << cc(color, kReset) << '\n';
         return offset + 1;
     }
 }

--- a/src/debug.h
+++ b/src/debug.h
@@ -7,10 +7,12 @@
 class Allocator;
 
 // Disassembles an entire chunk, printing a header followed by each instruction.
+// Pass color=true to emit ANSI escape codes; only do so when output is a TTY.
 void disassembleChunk(const Chunk& chunk, const Allocator& alloc,
-                      const char* name, std::ostream& out);
+                      const char* name, std::ostream& out, bool color = false);
 
 // Disassembles a single instruction at `offset`.
 // Returns the offset of the next instruction.
+// Pass color=true to emit ANSI escape codes; only do so when output is a TTY.
 int disassembleInstruction(const Chunk& chunk, const Allocator& alloc,
-                           int offset, std::ostream& out);
+                           int offset, std::ostream& out, bool color = false);

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -9,6 +9,7 @@
 #include <functional>
 #include <iostream>
 #include <string>
+#include <unistd.h>
 
 InterpretResult VM::interpret(const std::string& source) {
     auto chunk = compile(source, m_allocator.get());
@@ -42,6 +43,7 @@ InterpretResult VM::run() {
     for (;;) {
 #ifdef LOXPP_DEBUG_TRACE_EXECUTION
         int currentOffset = static_cast<int>(m_ip - m_chunk->cbegin());
+        bool color = isatty(STDOUT_FILENO) != 0;
         std::printf("[line %d] ", m_chunk->getLine(currentOffset));
         std::printf("          ");
         for (Value* slot = stack; slot < stackTop; slot++) {
@@ -50,8 +52,8 @@ InterpretResult VM::run() {
             std::printf(" ]");
         }
         std::printf("\n");
-        disassembleInstruction(*m_chunk, *m_allocator, currentOffset,
-                               std::cout);
+        disassembleInstruction(*m_chunk, *m_allocator, currentOffset, std::cout,
+                               color);
 #endif
 
         Byte instruction = readByte();


### PR DESCRIPTION
## What

Adds runtime-detected ANSI color output to the disassembler. No third-party libs, no CMake flags — just `isatty()`.

## Design

Color by **syntactic role**, not opcode category. Using different colors per opcode group (arithmetic = cyan, comparison = yellow…) creates visual noise with no payoff. Instead:

| Element | Style | Rationale |
|---|---|---|
| `== name ==` header | bold | Section separator |
| Offset `0:` | dim | Recedes; eyes land on opcode first |
| Opcode name | **bold** | Primary content — same style for all valid opcodes |
| Constant value `'foo'` | yellow | The value you actually want to read |
| `UNKNOWN` | **red + bold** | Error — must stand out |

## Implementation

- `bool color = false` added to both `disassembleChunk` and `disassembleInstruction` (default keeps all existing callers working, `test_harness.cpp` unchanged)
- 5 ANSI `constexpr const char*` codes + tiny `cc(bool, const char*)` helper inside an anonymous namespace in `debug.cpp`
- `compiler.cpp` and `vm.cpp`: `#include <unistd.h>` + `bool color = isatty(STDOUT_FILENO) != 0` at each call site

Color is never emitted when output is piped — CI, tests, and `| less` all get clean output automatically.