### PR TITLE
fix: prevent OOB in makeConstant when constant pool is full

### DIFF
--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -12,9 +12,11 @@ void Chunk::write(Byte byte, int line) {
 
 void Chunk::write(Op op, int line) { write(static_cast<Byte>(op), line); }
 
-uint8_t Chunk::addConstant(Value value) {
+std::optional<uint8_t> Chunk::addConstant(Value value) {
+    if (m_constants.isFull())
+        return std::nullopt;
     m_constants.write(value);
-    return m_constants.size() - 1;
+    return static_cast<uint8_t>(m_constants.size() - 1);
 }
 
 int Chunk::getLine(int offset) const {

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -3,6 +3,7 @@
 #include "value.h"
 
 #include <cstdint>
+#include <optional>
 #include <vector>
 #include <utility>
 
@@ -43,7 +44,7 @@ class Chunk : std::vector<Byte> {
 
     void write(Byte byte, int line);
     void write(Op op, int line);
-    uint8_t addConstant(Value value);
+    std::optional<uint8_t> addConstant(Value value);
     Value getConstant(int idx) const;
     int getLine(int offset) const;
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -198,16 +198,12 @@ void Compiler::emitBytes(Op op, Byte byte) {
 void Compiler::emitReturn() { emitByte(static_cast<Byte>(Op::RETURN)); }
 
 uint8_t Compiler::makeConstant(Value value) {
-    uint8_t constant = m_currentChunk->addConstant(value);
-
-    // ValueArray already hit illegal memory access at this point
-    // TODO: Handle this gracefully
-    if (constant >= UINT8_MAX) {
+    auto constant = m_currentChunk->addConstant(value);
+    if (!constant) {
         m_parser->error("Too many constants in one chunk.");
         return 0;
     }
-
-    return constant;
+    return *constant;
 }
 
 uint8_t Compiler::identifierConstant(const Token& name) {

--- a/src/value.h
+++ b/src/value.h
@@ -55,6 +55,7 @@ class ValueArray : std::array<Value, UINT8_MAX> {
     using std::array<Value, UINT8_MAX>::at;
     void write(Value value);
     uint8_t size() const;
+    bool isFull() const { return m_count >= UINT8_MAX; }
 
   private:
     uint8_t m_count = 0;

--- a/test/test_vm_runtime.cpp
+++ b/test/test_vm_runtime.cpp
@@ -259,3 +259,14 @@ TEST_F(CompileErrorTest, InvalidAssignmentTarget) {
     // Assigning to a non-lvalue: literal on the left of '='.
     EXPECT_EQ(h.run("1 + 2 = 3;"), InterpretResult::COMPILE_ERROR);
 }
+
+TEST_F(CompileErrorTest, TooManyConstants) {
+    // Generate 256 distinct numeric literal expression statements.
+    // The 256th constant exhausts the pool (capacity: 255) and must produce a
+    // compile error — not a crash or out-of-bounds exception.
+    std::string source;
+    for (int i = 0; i < 256; ++i)
+        source += std::to_string(i) + ";\n";
+    VMTestHarness h;
+    EXPECT_EQ(h.run(source), InterpretResult::COMPILE_ERROR);
+}


### PR DESCRIPTION
## Problem

`Compiler::makeConstant` had two compounding bugs that made its overflow guard completely ineffective:

1. **Check happens after the write**: `addConstant` calls `ValueArray::write()` before `makeConstant` ever checks the result. `ValueArray` is `std::array<Value, UINT8_MAX>` (255 slots, valid indices 0..254). When the 256th constant is added, `write` calls `at(255)` — out-of-bounds, triggering `std::out_of_range` or UB.

2. **Check condition is unreachable**: `constant >= UINT8_MAX` requires `addConstant` to return 255, but the OOB exception fires inside `write` before `addConstant` can return anything.

### Minimal reproducible example
```lox
0; 1; 2; ... 255;   // 256 distinct numeric literals in one chunk
```
This crashes/throws before the fix; returns `COMPILE_ERROR` after.

## Fix

Move the capacity check **inside** `Chunk::addConstant`, before the write. Return `std::optional<uint8_t>` (`nullopt` when full) so `makeConstant` can report a graceful compile error.

## Changes

- `src/value.h` — add `bool isFull() const` to `ValueArray`
- `src/chunk.h` — change `addConstant` → `std::optional<uint8_t>`, add `<optional>`
- `src/chunk.cpp` — check `isFull()` before writing; return `nullopt` if full
- `src/compiler.cpp` — handle the optional; remove stale comment and broken post-write check
- `test/test_vm_runtime.cpp` — add `CompileErrorTest.TooManyConstants` regression test (256 literals → `COMPILE_ERROR`)