### PR TITLE
feat: reduce string concatenation to one heap allocation

### DIFF
--- a/src/allocator.h
+++ b/src/allocator.h
@@ -3,6 +3,7 @@
 #include "object.h"
 
 #include <cstdint>
+#include <string>
 #include <string_view>
 
 struct ObjHandle {
@@ -17,6 +18,17 @@ struct ObjHandle {
 class Allocator {
   public:
     virtual ObjHandle makeString(std::string_view chars) = 0;
+    // Rvalue overload: moves an already-built std::string into the new
+    // ObjString, avoiding a second heap allocation in the common (non-interned)
+    // case. Default implementation falls back to the string_view overload.
+    virtual ObjHandle makeString(std::string&& chars) {
+        return makeString(std::string_view{chars});
+    }
+    // Disambiguate string literals: const char* is an exact match here, so
+    // overload resolution never sees the string_view / string&& ambiguity.
+    ObjHandle makeString(const char* chars) {
+        return makeString(std::string_view{chars});
+    }
     // Non-inserting lookup: returns the interned ObjString* if it exists, else
     // nullptr.
     virtual ObjString* findString(std::string_view chars) const = 0;

--- a/src/simple_allocator.cpp
+++ b/src/simple_allocator.cpp
@@ -32,6 +32,30 @@ ObjHandle SimpleAllocator::makeString(std::string_view chars) {
     return ObjHandle{index, ObjType::STRING};
 }
 
+ObjHandle SimpleAllocator::makeString(std::string&& chars) {
+    uint32_t hash = hashString(chars);
+
+    ObjString* interned = m_strings.findString(
+        chars.data(), static_cast<int>(chars.size()), hash);
+    if (interned) {
+        Value idxVal;
+        m_strings.get(interned, idxVal);
+        return ObjHandle{static_cast<uint32_t>(as<Number>(idxVal)),
+                         ObjType::STRING};
+    }
+
+    auto* str = new ObjString();
+    str->type = ObjType::STRING;
+    str->chars = std::move(chars);
+    str->hash = hash;
+
+    auto index = static_cast<uint32_t>(m_objects.size());
+    m_objects.push_back(static_cast<Obj*>(str));
+    m_strings.set(str, Value{static_cast<Number>(index)});
+
+    return ObjHandle{index, ObjType::STRING};
+}
+
 ObjString* SimpleAllocator::findString(std::string_view chars) const {
     uint32_t hash = hashString(chars);
     return m_strings.findString(chars.data(), static_cast<int>(chars.size()),

--- a/src/simple_allocator.h
+++ b/src/simple_allocator.h
@@ -11,7 +11,9 @@ class SimpleAllocator : public Allocator {
     SimpleAllocator() = default;
     ~SimpleAllocator() override;
 
+    using Allocator::makeString;
     ObjHandle makeString(std::string_view chars) override;
+    ObjHandle makeString(std::string&& chars) override;
     ObjString* findString(std::string_view chars) const override;
     Obj* deref(ObjHandle handle) const override;
     void collect() override;

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -110,12 +110,11 @@ InterpretResult VM::run() {
             if (isString(peek(0)) && isString(peek(1))) {
                 auto* b_str = asObjString(pop(), *m_allocator);
                 auto* a_str = asObjString(pop(), *m_allocator);
-                // std::string operator+ allocates a temporary; acceptable for
-                // now. TODO: consider pre-sizing a buffer and using append() or
-                // reserve()+memcpy() to match the book's single-allocation
-                // approach.
-                ObjHandle handle =
-                    m_allocator->makeString(a_str->chars + b_str->chars);
+                std::string result;
+                result.reserve(a_str->chars.size() + b_str->chars.size());
+                result.append(a_str->chars);
+                result.append(b_str->chars);
+                ObjHandle handle = m_allocator->makeString(std::move(result));
                 push(Value{handle});
             } else {
                 BINARY_OP(Number, +);


### PR DESCRIPTION
## Problem

`Op::ADD` for string concatenation did **two heap allocations** per non-interned result:

1. `a_str->chars + b_str->chars` — `std::string::operator+` creates a temporary (alloc #1)
2. `makeString(string_view)` → `str->chars = std::string(chars)` copies from the view into `ObjString::chars` (alloc #2), then the temporary is destroyed

The TODO comment in `vm.cpp` flagged this as an area to improve.

## Fix

Add a `makeString(std::string&&)` rvalue overload that **moves** the pre-built string directly into `ObjString::chars`, eliminating alloc #2 for non-interned strings.

`Op::ADD` now builds the concatenated string once using `reserve()`+`append()` and passes it via `std::move`.

## Interface changes

- `Allocator`: new `virtual makeString(std::string&&)` with a `string_view` fallback default; non-virtual `const char*` overload to prevent overload-resolution ambiguity in derived classes when calling with string literals.
- `SimpleAllocator`: `using Allocator::makeString` to expose the `const char*` overload; new `makeString(std::string&&)` override.

## Notes

No behaviour change — this is a pure allocation optimization. All existing tests pass unchanged.