### PR TITLE
feat: add ArenaAllocator — bump-allocate ObjString from memory blocks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(loxpp
     src/object.cpp
     src/table.cpp
     src/simple_allocator.cpp
+    src/arena_allocator.cpp
     src/vm.cpp 
     src/scanner.cpp 
     src/token.cpp 

--- a/src/arena_allocator.cpp
+++ b/src/arena_allocator.cpp
@@ -1,0 +1,79 @@
+#include "arena_allocator.h"
+
+#include "value.h"
+
+ArenaAllocator::~ArenaAllocator() {
+    for (ObjString* p : m_objects)
+        p->~ObjString();
+    // Block memory is freed by the unique_ptr destructors.
+}
+
+ObjString* ArenaAllocator::allocSlot() {
+    if (m_blocks.empty() || m_blocks.back()->count >= BLOCK_CAPACITY)
+        m_blocks.push_back(std::make_unique<Block>());
+
+    auto& block = *m_blocks.back();
+    auto* slot = reinterpret_cast<ObjString*>(block.data +
+                                              block.count * sizeof(ObjString));
+    ++block.count;
+    return slot;
+}
+
+ObjHandle ArenaAllocator::internHandle(ObjString* str) {
+    auto index = static_cast<uint32_t>(m_objects.size());
+    m_objects.push_back(str);
+    m_strings.set(str, Value{static_cast<Number>(index)});
+    return ObjHandle{index, ObjType::STRING};
+}
+
+ObjHandle ArenaAllocator::makeString(std::string_view chars) {
+    uint32_t hash = hashString(chars);
+
+    ObjString* interned = m_strings.findString(
+        chars.data(), static_cast<int>(chars.size()), hash);
+    if (interned) {
+        Value idxVal;
+        m_strings.get(interned, idxVal);
+        return ObjHandle{static_cast<uint32_t>(as<Number>(idxVal)),
+                         ObjType::STRING};
+    }
+
+    ObjString* str = new (allocSlot()) ObjString();
+    str->type = ObjType::STRING;
+    str->chars = std::string(chars);
+    str->hash = hash;
+    return internHandle(str);
+}
+
+ObjHandle ArenaAllocator::makeString(std::string&& chars) {
+    uint32_t hash = hashString(chars);
+
+    ObjString* interned = m_strings.findString(
+        chars.data(), static_cast<int>(chars.size()), hash);
+    if (interned) {
+        Value idxVal;
+        m_strings.get(interned, idxVal);
+        return ObjHandle{static_cast<uint32_t>(as<Number>(idxVal)),
+                         ObjType::STRING};
+    }
+
+    ObjString* str = new (allocSlot()) ObjString();
+    str->type = ObjType::STRING;
+    str->chars = std::move(chars);
+    str->hash = hash;
+    return internHandle(str);
+}
+
+ObjString* ArenaAllocator::findString(std::string_view chars) const {
+    uint32_t hash = hashString(chars);
+    return m_strings.findString(chars.data(), static_cast<int>(chars.size()),
+                                hash);
+}
+
+Obj* ArenaAllocator::deref(ObjHandle handle) const {
+    return m_objects[handle.index];
+}
+
+void ArenaAllocator::collect() {
+    // Stub: GC traversal not yet implemented.
+}

--- a/src/arena_allocator.h
+++ b/src/arena_allocator.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "allocator.h"
+#include "object.h"
+#include "table.h"
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+// ArenaAllocator allocates ObjString objects from pre-allocated memory blocks
+// using placement new, avoiding one heap allocation per string object compared
+// to SimpleAllocator's individual new/delete approach.
+//
+// Layout: objects are bump-allocated within fixed-size Blocks. When a Block is
+// exhausted a new one is appended. Stable ObjString* pointers into the blocks
+// are kept in m_objects for O(1) deref and orderly destruction.
+//
+// ObjString::chars (std::string) still individually heap-allocates; only the
+// ObjString struct memory comes from the arena.
+class ArenaAllocator : public Allocator {
+  public:
+    static constexpr std::size_t BLOCK_CAPACITY = 64;
+
+    ArenaAllocator() = default;
+    ~ArenaAllocator() override;
+
+    using Allocator::makeString;
+    ObjHandle makeString(std::string_view chars) override;
+    ObjHandle makeString(std::string&& chars) override;
+    ObjString* findString(std::string_view chars) const override;
+    Obj* deref(ObjHandle handle) const override;
+    void collect() override;
+
+  private:
+    struct Block {
+        alignas(ObjString) char data[BLOCK_CAPACITY * sizeof(ObjString)];
+        std::size_t count = 0;
+    };
+
+    // Bump-allocate one ObjString-sized slot from the current block,
+    // allocating a fresh block when the current one is full.
+    // Returns uninitialised memory — caller must use placement new.
+    ObjString* allocSlot();
+
+    ObjHandle internHandle(ObjString* str);
+
+    std::vector<std::unique_ptr<Block>> m_blocks;
+    std::vector<ObjString*>
+        m_objects; // stable pointers for deref + destruction
+    Table m_strings;
+};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,7 @@ find_package(GTest REQUIRED)
 
 set(ALLOC_SRCS
     ${PROJECT_SOURCE_DIR}/src/simple_allocator.cpp
+    ${PROJECT_SOURCE_DIR}/src/arena_allocator.cpp
     ${PROJECT_SOURCE_DIR}/src/object.cpp
     ${PROJECT_SOURCE_DIR}/src/table.cpp
     ${PROJECT_SOURCE_DIR}/src/value.cpp

--- a/test/test_allocator.cpp
+++ b/test/test_allocator.cpp
@@ -1,85 +1,93 @@
 #include "allocator.h"
+#include "arena_allocator.h"
 #include "simple_allocator.h"
 
 #include <gtest/gtest.h>
 
 #include <memory>
 
+// ---------------------------------------------------------------------------
+// Typed test fixture — runs all invariants against every Allocator impl.
+// ---------------------------------------------------------------------------
+
+template <typename T>
 class AllocatorTest : public ::testing::Test {
   protected:
     std::unique_ptr<Allocator> alloc;
-
-    void SetUp() override { alloc = std::make_unique<SimpleAllocator>(); }
+    void SetUp() override { alloc = std::make_unique<T>(); }
 };
 
+using AllocatorTypes = ::testing::Types<SimpleAllocator, ArenaAllocator>;
+TYPED_TEST_SUITE(AllocatorTest, AllocatorTypes);
+
 // ---------------------------------------------------------------------------
-// Phase 1 — Allocator interface + SimpleAllocator
+// Phase 1 — Allocator interface
 // ---------------------------------------------------------------------------
 
-TEST_F(AllocatorTest, MakeStringReturnsStringHandle) {
-    ObjHandle h = alloc->makeString("hello");
+TYPED_TEST(AllocatorTest, MakeStringReturnsStringHandle) {
+    ObjHandle h = this->alloc->makeString("hello");
     EXPECT_EQ(h.type, ObjType::STRING);
 }
 
-TEST_F(AllocatorTest, DerefReturnsCorrectChars) {
-    ObjHandle h = alloc->makeString("hello");
-    auto* str = static_cast<ObjString*>(alloc->deref(h));
+TYPED_TEST(AllocatorTest, DerefReturnsCorrectChars) {
+    ObjHandle h = this->alloc->makeString("hello");
+    auto* str = static_cast<ObjString*>(this->alloc->deref(h));
     EXPECT_EQ(str->chars, "hello");
 }
 
-TEST_F(AllocatorTest, MakeString_EmptyString) {
-    ObjHandle h = alloc->makeString("");
-    auto* str = static_cast<ObjString*>(alloc->deref(h));
+TYPED_TEST(AllocatorTest, MakeString_EmptyString) {
+    ObjHandle h = this->alloc->makeString("");
+    auto* str = static_cast<ObjString*>(this->alloc->deref(h));
     EXPECT_EQ(str->chars, "");
 }
 
-TEST_F(AllocatorTest, Interning_SameContent_SameHandle) {
-    ObjHandle h1 = alloc->makeString("x");
-    ObjHandle h2 = alloc->makeString("x");
+TYPED_TEST(AllocatorTest, Interning_SameContent_SameHandle) {
+    ObjHandle h1 = this->alloc->makeString("x");
+    ObjHandle h2 = this->alloc->makeString("x");
     EXPECT_EQ(h1, h2);
 }
 
-TEST_F(AllocatorTest, Interning_DifferentContent_DifferentHandle) {
-    ObjHandle h1 = alloc->makeString("a");
-    ObjHandle h2 = alloc->makeString("b");
+TYPED_TEST(AllocatorTest, Interning_DifferentContent_DifferentHandle) {
+    ObjHandle h1 = this->alloc->makeString("a");
+    ObjHandle h2 = this->alloc->makeString("b");
     EXPECT_NE(h1, h2);
 }
 
-TEST_F(AllocatorTest, HandleStability_AfterMoreAllocations) {
-    ObjHandle h1 = alloc->makeString("first");
-    ObjHandle h2 = alloc->makeString("second");
-    ObjHandle h3 = alloc->makeString("third");
+TYPED_TEST(AllocatorTest, HandleStability_AfterMoreAllocations) {
+    ObjHandle h1 = this->alloc->makeString("first");
+    ObjHandle h2 = this->alloc->makeString("second");
+    ObjHandle h3 = this->alloc->makeString("third");
 
-    EXPECT_EQ(static_cast<ObjString*>(alloc->deref(h1))->chars, "first");
-    EXPECT_EQ(static_cast<ObjString*>(alloc->deref(h2))->chars, "second");
-    EXPECT_EQ(static_cast<ObjString*>(alloc->deref(h3))->chars, "third");
+    EXPECT_EQ(static_cast<ObjString*>(this->alloc->deref(h1))->chars, "first");
+    EXPECT_EQ(static_cast<ObjString*>(this->alloc->deref(h2))->chars, "second");
+    EXPECT_EQ(static_cast<ObjString*>(this->alloc->deref(h3))->chars, "third");
 }
 
-TEST_F(AllocatorTest, PolymorphicUsage_ViaInterfacePointer) {
-    std::unique_ptr<Allocator> a = std::make_unique<SimpleAllocator>();
+TYPED_TEST(AllocatorTest, PolymorphicUsage_ViaInterfacePointer) {
+    std::unique_ptr<Allocator> a = std::make_unique<TypeParam>();
     ObjHandle h = a->makeString("poly");
     auto* str = static_cast<ObjString*>(a->deref(h));
     EXPECT_EQ(str->chars, "poly");
 }
 
-TEST_F(AllocatorTest, Collect_DoesNotCrash) {
-    alloc->makeString("gc1");
-    alloc->makeString("gc2");
-    alloc->makeString("gc3");
-    EXPECT_NO_FATAL_FAILURE(alloc->collect());
+TYPED_TEST(AllocatorTest, Collect_DoesNotCrash) {
+    this->alloc->makeString("gc1");
+    this->alloc->makeString("gc2");
+    this->alloc->makeString("gc3");
+    EXPECT_NO_FATAL_FAILURE(this->alloc->collect());
 }
 
 // ---------------------------------------------------------------------------
 // Phase 2 — ObjHandle in Value
 // ---------------------------------------------------------------------------
 
-TEST_F(AllocatorTest, ValueHoldsObjHandle) {
-    Value v{alloc->makeString("hi")};
+TYPED_TEST(AllocatorTest, ValueHoldsObjHandle) {
+    Value v{this->alloc->makeString("hi")};
     EXPECT_TRUE(is<ObjHandle>(v));
 }
 
-TEST_F(AllocatorTest, IsString_TrueForStringHandle) {
-    Value vStr{alloc->makeString("hello")};
+TYPED_TEST(AllocatorTest, IsString_TrueForStringHandle) {
+    Value vStr{this->alloc->makeString("hello")};
     Value vNum{42.0};
     Value vNil{Nil{}};
     EXPECT_TRUE(isString(vStr));
@@ -87,19 +95,38 @@ TEST_F(AllocatorTest, IsString_TrueForStringHandle) {
     EXPECT_FALSE(isString(vNil));
 }
 
-TEST_F(AllocatorTest, Stringify_ViaAllocator) {
-    Value v{alloc->makeString("hi")};
-    EXPECT_EQ(stringify(v, *alloc), "hi");
+TYPED_TEST(AllocatorTest, Stringify_ViaAllocator) {
+    Value v{this->alloc->makeString("hi")};
+    EXPECT_EQ(stringify(v, *this->alloc), "hi");
 }
 
-TEST_F(AllocatorTest, EqualHandles_SameInternedString) {
-    Value a{alloc->makeString("x")};
-    Value b{alloc->makeString("x")};
+TYPED_TEST(AllocatorTest, EqualHandles_SameInternedString) {
+    Value a{this->alloc->makeString("x")};
+    Value b{this->alloc->makeString("x")};
     EXPECT_EQ(a, b);
 }
 
-TEST_F(AllocatorTest, UnequalHandles_DifferentStrings) {
-    Value a{alloc->makeString("x")};
-    Value b{alloc->makeString("y")};
+TYPED_TEST(AllocatorTest, UnequalHandles_DifferentStrings) {
+    Value a{this->alloc->makeString("x")};
+    Value b{this->alloc->makeString("y")};
     EXPECT_NE(a, b);
+}
+
+// ---------------------------------------------------------------------------
+// ArenaAllocator-specific — exercises block overflow (> BLOCK_CAPACITY strings)
+// ---------------------------------------------------------------------------
+
+TEST(ArenaAllocatorTest, HandlesMoreThanOneBlock) {
+    ArenaAllocator alloc;
+    const std::size_t count = ArenaAllocator::BLOCK_CAPACITY * 3;
+    std::vector<ObjHandle> handles;
+    handles.reserve(count);
+    for (std::size_t i = 0; i < count; ++i)
+        handles.push_back(alloc.makeString(std::to_string(i)));
+
+    // Verify all strings are intact after multi-block allocation.
+    for (std::size_t i = 0; i < count; ++i) {
+        auto* str = static_cast<ObjString*>(alloc.deref(handles[i]));
+        EXPECT_EQ(str->chars, std::to_string(i));
+    }
 }


### PR DESCRIPTION
## Summary

Adds `ArenaAllocator`, a second `Allocator` implementation that pre-allocates blocks of `ObjString` slots and uses **placement new** to construct objects within them, instead of calling `new ObjString()` individually.

## Problem with SimpleAllocator

Every interned string costs one `malloc` + one `free` (via `new`/`delete`). This means per-object allocator overhead and scattered memory.

## Design

- **Block**: `alignas(ObjString) char data[64 * sizeof(ObjString)]` — 64 slots per block, bump-allocated via a `count` field.
- **`allocSlot()`**: returns the next available slot; appends a new `Block` when the current is full (growable, no hard cap).
- **`makeString`**: same interning logic as `SimpleAllocator`, but uses placement new: `new (allocSlot()) ObjString()`.
- **Destructor**: calls `~ObjString()` explicitly on each placed object (required for placement new), then `unique_ptr` frees the block memory.
- **`deref(handle)`**: O(1) via a flat `m_objects` vector of stable pointers into the blocks.
- **`ObjString::chars`** (`std::string`) is unchanged — only the struct memory comes from the arena.

## Testing

- `test_allocator.cpp` converted to **`TYPED_TEST`** over `{SimpleAllocator, ArenaAllocator}` — all 10 existing invariants now run against both implementations automatically.
- New `ArenaAllocatorTest.HandlesMoreThanOneBlock`: allocates `3 × BLOCK_CAPACITY` strings and verifies all are intact after block overflow.