### PR TITLE
fix: route all ObjString heap memory through Allocator::reallocate

### DIFF
--- a/src/allocator.h
+++ b/src/allocator.h
@@ -2,6 +2,7 @@
 
 #include "object.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <string_view>
@@ -17,10 +18,17 @@ struct ObjHandle {
 
 class Allocator {
   public:
+    // Single gateway for all raw heap memory managed by this allocator.
+    // - ptr == nullptr, oldSize == 0: fresh allocation of newSize bytes.
+    // - newSize == 0: free ptr (oldSize bytes); returns nullptr.
+    // - otherwise: resize ptr from oldSize to newSize bytes.
+    // Implementations must update their byte-tracking bookkeeping here.
+    virtual void* reallocate(void* ptr, size_t oldSize, size_t newSize) = 0;
+
     virtual ObjHandle makeString(std::string_view chars) = 0;
-    // Rvalue overload: moves an already-built std::string into the new
-    // ObjString, avoiding a second heap allocation in the common (non-interned)
-    // case. Default implementation falls back to the string_view overload.
+    // Rvalue overload: takes an already-built std::string, avoiding a redundant
+    // copy in the common (non-interned) path.
+    // Default implementation falls back to the string_view overload.
     virtual ObjHandle makeString(std::string&& chars) {
         return makeString(std::string_view{chars});
     }
@@ -34,5 +42,7 @@ class Allocator {
     virtual ObjString* findString(std::string_view chars) const = 0;
     virtual Obj* deref(ObjHandle handle) const = 0;
     virtual void collect() = 0;
+    // Total bytes currently allocated through this allocator.
+    virtual size_t bytesAllocated() const = 0;
     virtual ~Allocator() = default;
 };

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -5,8 +5,10 @@
 
 std::string stringifyObj(Obj* obj) {
     switch (obj->type) {
-    case ObjType::STRING:
-        return asObjString(obj)->chars;
+    case ObjType::STRING: {
+        auto* s = asObjString(obj);
+        return std::string(s->chars, s->length);
+    }
     }
     return "<obj>";
 }

--- a/src/object.h
+++ b/src/object.h
@@ -13,8 +13,11 @@ struct Obj {
 };
 
 struct ObjString : public Obj {
-    std::string chars;
+    uint32_t length{0};
     uint32_t hash{0};
+    // Null-terminated char buffer allocated and freed via
+    // Allocator::reallocate.
+    char* chars{nullptr};
 };
 
 std::string stringifyObj(Obj* obj);
@@ -23,5 +26,5 @@ void printObject(Obj* obj);
 inline bool isObjType(Obj* obj, ObjType type) { return obj->type == type; }
 inline ObjString* asObjString(Obj* obj) { return static_cast<ObjString*>(obj); }
 inline const char* asCString(Obj* obj) {
-    return static_cast<ObjString*>(obj)->chars.c_str();
+    return static_cast<ObjString*>(obj)->chars;
 }

--- a/src/simple_allocator.cpp
+++ b/src/simple_allocator.cpp
@@ -2,9 +2,64 @@
 
 #include "value.h"
 
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <new>
+
+void* SimpleAllocator::reallocateImpl(void* ptr, size_t oldSize,
+                                      size_t newSize) {
+    m_bytesAllocated += newSize;
+    m_bytesAllocated -= oldSize;
+
+    if (newSize == 0) {
+        ::operator delete(ptr);
+        return nullptr;
+    }
+
+    void* result = ::operator new(newSize);
+    if (ptr != nullptr) {
+        std::memcpy(result, ptr, std::min(oldSize, newSize));
+        ::operator delete(ptr);
+    }
+    return result;
+}
+
+void* SimpleAllocator::reallocate(void* ptr, size_t oldSize, size_t newSize) {
+    return reallocateImpl(ptr, oldSize, newSize);
+}
+
+// Allocates and constructs a new ObjString whose char buffer is tracked via
+// reallocate. Returns the index of the new object in m_objects.
+static ObjString* allocString(SimpleAllocator& alloc, const char* data,
+                              uint32_t length, uint32_t hash) {
+    auto* str = static_cast<ObjString*>(
+        alloc.reallocate(nullptr, 0, sizeof(ObjString)));
+    ::new (str) ObjString{};
+    str->type = ObjType::STRING;
+    str->length = length;
+    str->hash = hash;
+    str->chars = static_cast<char*>(alloc.reallocate(nullptr, 0, length + 1));
+    std::memcpy(str->chars, data, length);
+    str->chars[length] = '\0';
+    return str;
+}
+
 SimpleAllocator::~SimpleAllocator() {
     for (Obj* obj : m_objects) {
-        delete obj;
+        freeObject(obj);
+    }
+}
+
+void SimpleAllocator::freeObject(Obj* obj) {
+    switch (obj->type) {
+    case ObjType::STRING: {
+        auto* str = static_cast<ObjString*>(obj);
+        reallocateImpl(str->chars, str->length + 1, 0);
+        str->~ObjString();
+        reallocateImpl(str, sizeof(ObjString), 0);
+        break;
+    }
     }
 }
 
@@ -20,11 +75,8 @@ ObjHandle SimpleAllocator::makeString(std::string_view chars) {
                          ObjType::STRING};
     }
 
-    auto* str = new ObjString();
-    str->type = ObjType::STRING;
-    str->chars = std::string(chars);
-    str->hash = hash;
-
+    ObjString* str = allocString(*this, chars.data(),
+                                 static_cast<uint32_t>(chars.size()), hash);
     auto index = static_cast<uint32_t>(m_objects.size());
     m_objects.push_back(static_cast<Obj*>(str));
     m_strings.set(str, Value{static_cast<Number>(index)});
@@ -44,11 +96,8 @@ ObjHandle SimpleAllocator::makeString(std::string&& chars) {
                          ObjType::STRING};
     }
 
-    auto* str = new ObjString();
-    str->type = ObjType::STRING;
-    str->chars = std::move(chars);
-    str->hash = hash;
-
+    ObjString* str = allocString(*this, chars.data(),
+                                 static_cast<uint32_t>(chars.size()), hash);
     auto index = static_cast<uint32_t>(m_objects.size());
     m_objects.push_back(static_cast<Obj*>(str));
     m_strings.set(str, Value{static_cast<Number>(index)});

--- a/src/simple_allocator.h
+++ b/src/simple_allocator.h
@@ -11,14 +11,21 @@ class SimpleAllocator : public Allocator {
     SimpleAllocator() = default;
     ~SimpleAllocator() override;
 
+    void* reallocate(void* ptr, size_t oldSize, size_t newSize) override;
+
     using Allocator::makeString;
     ObjHandle makeString(std::string_view chars) override;
     ObjHandle makeString(std::string&& chars) override;
     ObjString* findString(std::string_view chars) const override;
     Obj* deref(ObjHandle handle) const override;
     void collect() override;
+    size_t bytesAllocated() const override { return m_bytesAllocated; }
 
   private:
+    // Non-virtual core of reallocate; safe to call during destruction.
+    void* reallocateImpl(void* ptr, size_t oldSize, size_t newSize);
+    void freeObject(Obj* obj);
+
     std::vector<Obj*> m_objects;
     Table m_strings;
     std::size_t m_bytesAllocated = 0;

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -115,9 +115,9 @@ ObjString* Table::findString(const char* chars, int length,
             // Stop only on a truly empty slot; skip tombstones.
             if (is<Nil>(entry.value))
                 return nullptr;
-        } else if (static_cast<int>(entry.key->chars.size()) == length &&
+        } else if (static_cast<int>(entry.key->length) == length &&
                    entry.key->hash == hash &&
-                   memcmp(entry.key->chars.c_str(), chars, length) == 0) {
+                   memcmp(entry.key->chars, chars, length) == 0) {
             return entry.key;
         }
         index = (index + 1) % static_cast<uint32_t>(cap);

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -111,9 +111,9 @@ InterpretResult VM::run() {
                 auto* b_str = asObjString(pop(), *m_allocator);
                 auto* a_str = asObjString(pop(), *m_allocator);
                 std::string result;
-                result.reserve(a_str->chars.size() + b_str->chars.size());
-                result.append(a_str->chars);
-                result.append(b_str->chars);
+                result.reserve(a_str->length + b_str->length);
+                result.append(a_str->chars, a_str->length);
+                result.append(b_str->chars, b_str->length);
                 ObjHandle handle = m_allocator->makeString(std::move(result));
                 push(Value{handle});
             } else {
@@ -156,7 +156,7 @@ InterpretResult VM::run() {
             ObjString* name = asObjString(readConstant(), *m_allocator);
             Value value;
             if (!m_globals.get(name, value)) {
-                runtimeError("Undefined variable '%s'.", name->chars.c_str());
+                runtimeError("Undefined variable '%s'.", name->chars);
                 return InterpretResult::RUNTIME_ERROR;
             }
             push(value);
@@ -168,7 +168,7 @@ InterpretResult VM::run() {
             // An entirely new key means the variable was never declared.
             if (m_globals.set(name, peek(0))) {
                 m_globals.del(name); // undo the spurious insertion
-                runtimeError("Undefined variable '%s'.", name->chars.c_str());
+                runtimeError("Undefined variable '%s'.", name->chars);
                 return InterpretResult::RUNTIME_ERROR;
             }
             break;

--- a/test/test_allocator.cpp
+++ b/test/test_allocator.cpp
@@ -24,13 +24,13 @@ TEST_F(AllocatorTest, MakeStringReturnsStringHandle) {
 TEST_F(AllocatorTest, DerefReturnsCorrectChars) {
     ObjHandle h = alloc->makeString("hello");
     auto* str = static_cast<ObjString*>(alloc->deref(h));
-    EXPECT_EQ(str->chars, "hello");
+    EXPECT_EQ(std::string_view(str->chars, str->length), "hello");
 }
 
 TEST_F(AllocatorTest, MakeString_EmptyString) {
     ObjHandle h = alloc->makeString("");
     auto* str = static_cast<ObjString*>(alloc->deref(h));
-    EXPECT_EQ(str->chars, "");
+    EXPECT_EQ(std::string_view(str->chars, str->length), "");
 }
 
 TEST_F(AllocatorTest, Interning_SameContent_SameHandle) {
@@ -50,16 +50,19 @@ TEST_F(AllocatorTest, HandleStability_AfterMoreAllocations) {
     ObjHandle h2 = alloc->makeString("second");
     ObjHandle h3 = alloc->makeString("third");
 
-    EXPECT_EQ(static_cast<ObjString*>(alloc->deref(h1))->chars, "first");
-    EXPECT_EQ(static_cast<ObjString*>(alloc->deref(h2))->chars, "second");
-    EXPECT_EQ(static_cast<ObjString*>(alloc->deref(h3))->chars, "third");
+    auto* s1 = static_cast<ObjString*>(alloc->deref(h1));
+    auto* s2 = static_cast<ObjString*>(alloc->deref(h2));
+    auto* s3 = static_cast<ObjString*>(alloc->deref(h3));
+    EXPECT_EQ(std::string_view(s1->chars, s1->length), "first");
+    EXPECT_EQ(std::string_view(s2->chars, s2->length), "second");
+    EXPECT_EQ(std::string_view(s3->chars, s3->length), "third");
 }
 
 TEST_F(AllocatorTest, PolymorphicUsage_ViaInterfacePointer) {
     std::unique_ptr<Allocator> a = std::make_unique<SimpleAllocator>();
     ObjHandle h = a->makeString("poly");
     auto* str = static_cast<ObjString*>(a->deref(h));
-    EXPECT_EQ(str->chars, "poly");
+    EXPECT_EQ(std::string_view(str->chars, str->length), "poly");
 }
 
 TEST_F(AllocatorTest, Collect_DoesNotCrash) {
@@ -102,4 +105,49 @@ TEST_F(AllocatorTest, UnequalHandles_DifferentStrings) {
     Value a{alloc->makeString("x")};
     Value b{alloc->makeString("y")};
     EXPECT_NE(a, b);
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3 — Tracked allocation (reallocate + bytesAllocated)
+// ---------------------------------------------------------------------------
+
+TEST_F(AllocatorTest, BytesAllocated_StartsAtZero) {
+    EXPECT_EQ(alloc->bytesAllocated(), 0u);
+}
+
+TEST_F(AllocatorTest, BytesAllocated_IncreasesOnMakeString) {
+    alloc->makeString("hello");
+    // struct + null-terminated char buffer (5 chars + '\0' = 6 bytes) +
+    // sizeof(ObjString)
+    EXPECT_GT(alloc->bytesAllocated(), 0u);
+}
+
+TEST_F(AllocatorTest, BytesAllocated_IncreasesWithEachNewString) {
+    alloc->makeString("abc");
+    size_t after_one = alloc->bytesAllocated();
+    alloc->makeString("defgh"); // longer string → more bytes
+    EXPECT_GT(alloc->bytesAllocated(), after_one);
+}
+
+TEST_F(AllocatorTest, BytesAllocated_InternedStringDoesNotIncrease) {
+    alloc->makeString("same");
+    size_t after_first = alloc->bytesAllocated();
+    alloc->makeString("same"); // interned — no new allocation
+    EXPECT_EQ(alloc->bytesAllocated(), after_first);
+}
+
+TEST_F(AllocatorTest, BytesAllocated_DecreasesOnDestruction) {
+    {
+        SimpleAllocator inner;
+        inner.makeString("temp");
+        EXPECT_GT(inner.bytesAllocated(), 0u);
+        // destructor frees all objects — bytesAllocated reaches 0
+    }
+    // No crash and memory is freed (verified by sanitizers at runtime)
+}
+
+TEST_F(AllocatorTest, CharsBuffer_IsNullTerminated) {
+    ObjHandle h = alloc->makeString("lox");
+    auto* str = static_cast<ObjString*>(alloc->deref(h));
+    EXPECT_EQ(str->chars[str->length], '\0');
 }

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -393,8 +393,7 @@ TEST_F(TableTest, FindStringPresentReturnsPointer) {
 TEST_F(TableTest, FindStringHashCollisionDifferentContentReturnsNull) {
     auto [a, b] = collidingPair();
     table.set(a, Value{std::monostate{}});
-    EXPECT_EQ(table.findString(b->chars.c_str(),
-                               static_cast<int>(b->chars.size()), b->hash),
+    EXPECT_EQ(table.findString(b->chars, static_cast<int>(b->length), b->hash),
               nullptr);
 }
 
@@ -402,7 +401,7 @@ TEST_F(TableTest, FindStringByRawCharsWithoutObjStringWrapper) {
     ObjString* k = str("lookup_me");
     table.set(k, Value{std::monostate{}});
     const char* raw = "lookup_me";
-    int len = static_cast<int>(k->chars.size());
+    int len = static_cast<int>(k->length);
     uint32_t h = fakeHash(raw, len);
     EXPECT_EQ(table.findString(raw, len, h), k);
 }


### PR DESCRIPTION
## Problem

`ObjString::chars` was a `std::string` whose internal heap buffer was invisible to the allocator — `m_bytesAllocated` was always zero and the GC could never account for string data.

## Changes

- **`Allocator`**: Add `reallocate(ptr, oldSize, newSize)` as the single gateway for all raw heap memory; add `bytesAllocated()` query.
- **`ObjString`**: Replace `std::string chars` with `char* chars + uint32_t length`. The null-terminated buffer is allocated and freed exclusively via `reallocate`, so every byte of every string is now tracked.
- **`SimpleAllocator`**: Implement `reallocate` via a private `reallocateImpl` (avoids virtual-call-during-destruction UB caught by clang-tidy). Replace `delete obj` with `freeObject()` which explicitly frees the char buffer then the struct through `reallocateImpl`.
- **Callers**: Update `table.cpp`, `vm.cpp`, `object.cpp`, `test_table.cpp`.
- **Tests**: Add Phase 3 allocator tests covering `bytesAllocated` tracking, null-termination, interning invariants.

## Verification

All 7 test suites pass. clang-format clean. clang-tidy: no new errors (pre-existing warnings unchanged).