### PR TITLE
feat: add ObjFunction, call frames, and Op::CALL

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -33,6 +33,7 @@ enum class Op : Byte {
     JUMP,
     JUMP_IF_FALSE,
     LOOP,
+    CALL,
     RETURN,
 };
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -7,10 +7,10 @@
 #include <memory>
 #include <unistd.h>
 
-std::unique_ptr<Chunk> compile(const std::string& source, MemoryManager* mm) {
-    auto chunk = std::make_unique<Chunk>();
+ObjFunction* compile(const std::string& source, MemoryManager* mm) {
+    ObjFunction* fn = mm->create<ObjFunction>();
     auto parser = std::make_unique<Parser>(source);
-    auto compiler = std::make_unique<Compiler>(chunk.get(), parser.get(), mm);
+    auto compiler = std::make_unique<Compiler>(fn, parser.get(), mm);
 
     while (!parser->check(TokenType::EOF_))
         compiler->declaration();
@@ -19,17 +19,26 @@ std::unique_ptr<Chunk> compile(const std::string& source, MemoryManager* mm) {
 
     if (parser->m_hadError)
         return nullptr;
-    return chunk;
+    return fn;
 }
 
-Compiler::Compiler(Chunk* chunk, Parser* parser, MemoryManager* mm)
-    : m_currentChunk{chunk}, m_parser{parser}, m_mm{mm} {}
+Compiler::Compiler(ObjFunction* function, Parser* parser, MemoryManager* mm)
+    : m_function{function}, m_parser{parser}, m_mm{mm} {
+    // Reserve slot 0 for the function/script itself. User-declared locals
+    // start at slot 1. The implicit local has an empty name so resolveLocal
+    // never accidentally matches it.
+    Local* implicit = &m_locals[m_localCount++];
+    implicit->depth = 0;
+    implicit->name = Token{TokenType::IDENTIFIER, "", 0};
+}
 
 void Compiler::endCompiler() {
     emitReturn();
 #ifdef LOXPP_DEBUG_PRINT_CODE
     bool color = isatty(STDOUT_FILENO) != 0;
-    disassembleChunk(*m_currentChunk, *m_mm, "code", std::cout, color);
+    const char* name =
+        m_function->name ? m_function->name->chars.c_str() : "script";
+    disassembleChunk(*getCurrentChunk(), *m_mm, name, std::cout, color);
 #endif
 }
 
@@ -138,6 +147,22 @@ void Compiler::string() {
 
 void Compiler::variable() {
     namedVariable(m_parser->m_previous, m_parser->m_canAssign);
+}
+
+void Compiler::call() {
+    // The callee is already on the stack. Parse the argument list.
+    uint8_t argCount = 0;
+    if (!m_parser->check(TokenType::RIGHT_PAREN)) {
+        do {
+            if (argCount == 255) {
+                m_parser->error("Can't have more than 255 arguments.");
+            }
+            expression();
+            argCount++;
+        } while (m_parser->match(TokenType::COMMA));
+    }
+    m_parser->consume(TokenType::RIGHT_PAREN, "Expect ')' after arguments.");
+    emitBytes(Op::CALL, argCount);
 }
 
 void Compiler::declaration() {
@@ -285,7 +310,7 @@ void Compiler::ifStatement() {
 }
 
 void Compiler::whileStatement() {
-    int loopStart = static_cast<int>(m_currentChunk->size());
+    int loopStart = static_cast<int>(getCurrentChunk()->size());
     m_loopStack.push_back({loopStart, m_localCount, {}});
 
     m_parser->consume(TokenType::LEFT_PAREN, "Expect '(' after 'while'.");
@@ -318,7 +343,7 @@ void Compiler::forStatement() {
         expressionStatement();
     }
 
-    int loopStart = static_cast<int>(m_currentChunk->size());
+    int loopStart = static_cast<int>(getCurrentChunk()->size());
     m_loopStack.push_back({loopStart, m_localCount, {}});
 
     int exitJump = -1;
@@ -332,7 +357,7 @@ void Compiler::forStatement() {
 
     if (!m_parser->match(TokenType::RIGHT_PAREN)) {
         int bodyJump = emitJump(Op::JUMP);
-        int incrStart = static_cast<int>(m_currentChunk->size());
+        int incrStart = static_cast<int>(getCurrentChunk()->size());
         expression();
         emitByte(Op::POP);
         m_parser->consume(TokenType::RIGHT_PAREN,
@@ -395,10 +420,13 @@ void Compiler::or_() {
     patchJump(endJump);
 }
 
-void Compiler::emitReturn() { emitByte(static_cast<Byte>(Op::RETURN)); }
+void Compiler::emitReturn() {
+    emitByte(Op::NIL);
+    emitByte(static_cast<Byte>(Op::RETURN));
+}
 
 void Compiler::emitByte(Byte byte) {
-    m_currentChunk->write(byte, m_parser->m_previous.line);
+    getCurrentChunk()->write(byte, m_parser->m_previous.line);
 }
 
 void Compiler::emitByte(Op op) { emitByte(static_cast<Byte>(op)); }
@@ -412,22 +440,22 @@ int Compiler::emitJump(Op op) {
     emitByte(op);
     emitByte(0xff);
     emitByte(0xff);
-    return static_cast<int>(m_currentChunk->size()) - 2;
+    return static_cast<int>(getCurrentChunk()->size()) - 2;
 }
 
 void Compiler::patchJump(int offset) {
-    int jump = static_cast<int>(m_currentChunk->size()) - offset - 2;
+    int jump = static_cast<int>(getCurrentChunk()->size()) - offset - 2;
     if (jump > UINT16_MAX) {
         m_parser->error("Too much code to jump over.");
         return;
     }
-    m_currentChunk->patch(offset, static_cast<uint8_t>((jump >> 8) & 0xff));
-    m_currentChunk->patch(offset + 1, static_cast<uint8_t>(jump & 0xff));
+    getCurrentChunk()->patch(offset, static_cast<uint8_t>((jump >> 8) & 0xff));
+    getCurrentChunk()->patch(offset + 1, static_cast<uint8_t>(jump & 0xff));
 }
 
 void Compiler::emitLoop(int loopStart) {
     emitByte(Op::LOOP);
-    int offset = static_cast<int>(m_currentChunk->size()) - loopStart + 2;
+    int offset = static_cast<int>(getCurrentChunk()->size()) - loopStart + 2;
     if (offset > UINT16_MAX) {
         m_parser->error("Loop body too large.");
         return;
@@ -443,7 +471,7 @@ void Compiler::emitLoopCleanup() {
 }
 
 uint8_t Compiler::makeConstant(Value value) {
-    auto constant = m_currentChunk->addConstant(value);
+    auto constant = getCurrentChunk()->addConstant(value);
     if (!constant) {
         m_parser->error("Too many constants in one chunk.");
         return 0;

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "chunk.h"
+#include "function.h"
 #include "parser.h"
 
 #include <memory>
@@ -11,11 +11,11 @@ class MemoryManager;
 
 static constexpr int UINT8_COUNT = 256;
 
-std::unique_ptr<Chunk> compile(const std::string& source, MemoryManager* mm);
+ObjFunction* compile(const std::string& source, MemoryManager* mm);
 
 struct Local {
     Token name;
-    int depth; // -1 = declared but not yet initialized; ≥0 = scope depth
+    int depth; // -1 = declared but not yet initialized; >=0 = scope depth
 };
 
 struct LoopContext {
@@ -27,9 +27,9 @@ struct LoopContext {
 
 class Compiler {
   public:
-    Compiler(Chunk* chunk, Parser* parser, MemoryManager* mm);
+    Compiler(ObjFunction* function, Parser* parser, MemoryManager* mm);
 
-    Chunk* getCurrentChunk() const { return m_currentChunk; }
+    Chunk* getCurrentChunk() const { return &m_function->chunk; }
     void endCompiler();
 
     void expression();
@@ -40,6 +40,7 @@ class Compiler {
     void number();
     void string();
     void variable();
+    void call();
 
     void declaration();
     void statement();
@@ -78,7 +79,7 @@ class Compiler {
     uint8_t identifierConstant(const Token& name);
     void namedVariable(const Token& name, bool canAssign);
 
-    Chunk* m_currentChunk;
+    ObjFunction* m_function;
     Parser* m_parser;
     MemoryManager* m_mm;
 

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -113,6 +113,8 @@ int disassembleInstruction(const Chunk& chunk, const MemoryManager& mm,
         return jumpInstruction("JUMP_IF_FALSE", 1, chunk, offset, out, color);
     case Op::LOOP:
         return jumpInstruction("LOOP", -1, chunk, offset, out, color);
+    case Op::CALL:
+        return byteInstruction("CALL", chunk, offset, out, color);
     case Op::RETURN:
         return simpleInstruction("RETURN", offset, out, color);
     default:

--- a/src/function.h
+++ b/src/function.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "chunk.h"
+#include "object.h"
+#include "value.h"
+
+struct ObjFunction : public Obj {
+    int arity{0};
+    ObjString* name{nullptr}; // null for top-level script
+    Chunk chunk;
+
+    ObjFunction() : Obj(ObjType::FUNCTION) {}
+};
+
+inline bool isObjFunction(Obj* obj) {
+    return isObjType(obj, ObjType::FUNCTION);
+}
+inline ObjFunction* asObjFunction(Obj* obj) {
+    return static_cast<ObjFunction*>(obj);
+}
+inline ObjFunction* asObjFunction(const Value& v) {
+    return static_cast<ObjFunction*>(as<Obj*>(v));
+}

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1,4 +1,5 @@
 #include "object.h"
+#include "function.h"
 
 #include <cstdio>
 #include <string>
@@ -8,6 +9,14 @@ std::string stringifyObj(Obj* obj) {
     case ObjType::STRING: {
         const auto& s = asObjString(obj)->chars;
         return {s.data(), s.size()};
+    }
+    case ObjType::FUNCTION: {
+        auto* fn = asObjFunction(obj);
+        if (fn->name == nullptr)
+            return "<script>";
+        return "<fn " +
+               std::string(fn->name->chars.data(), fn->name->chars.size()) +
+               ">";
     }
     }
     return "<obj>";

--- a/src/object.h
+++ b/src/object.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <string_view>
 
-enum class ObjType : uint8_t { STRING };
+enum class ObjType : uint8_t { STRING, FUNCTION };
 
 inline uint32_t hashString(std::string_view s) {
     uint32_t hash = 2166136261U;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -8,7 +8,7 @@
 // clang-format off
 static const ParseRule rules[] = {
     // TokenType         Prefix              Infix              Precedence
-    RULE(LEFT_PAREN,     &Compiler::grouping, nullptr,           CALL),
+    RULE(LEFT_PAREN,     &Compiler::grouping, &Compiler::call,    CALL),
     RULE(RIGHT_PAREN,    nullptr,             nullptr,           NONE),
     RULE(LEFT_BRACE,     nullptr,             nullptr,           NONE),
     RULE(RIGHT_BRACE,    nullptr,             nullptr,           NONE),

--- a/src/value.h
+++ b/src/value.h
@@ -31,6 +31,9 @@ inline bool isObj(const Value& v) { return is<Obj*>(v); }
 inline bool isString(const Value& v) {
     return is<Obj*>(v) && as<Obj*>(v)->type == ObjType::STRING;
 }
+inline bool isFunction(const Value& v) {
+    return is<Obj*>(v) && as<Obj*>(v)->type == ObjType::FUNCTION;
+}
 inline Obj* asObj(const Value& v) { return as<Obj*>(v); }
 inline ObjString* asObjString(const Value& v) {
     return static_cast<ObjString*>(as<Obj*>(v));

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -273,15 +273,15 @@ void VM::runtimeError(const char* format, ...) {
 
     // Print a stack trace (innermost frame first).
     for (int i = m_frameCount - 1; i >= 0; i--) {
-        const CallFrame& f = m_frames[i];
-        const Chunk& chunk = f.function->chunk;
-        auto offset = static_cast<int>(f.ip - chunk.cbegin()) - 1;
+        const CallFrame& frame = m_frames[i];
+        const Chunk& chunk = frame.function->chunk;
+        auto offset = static_cast<int>(frame.ip - chunk.cbegin()) - 1;
         int line = chunk.getLine(offset);
         std::fprintf(stderr, "[line %d] in ", line);
-        if (f.function->name == nullptr) {
+        if (frame.function->name == nullptr) {
             std::fprintf(stderr, "script\n");
         } else {
-            std::fprintf(stderr, "%s()\n", f.function->name->chars.c_str());
+            std::fprintf(stderr, "%s()\n", frame.function->name->chars.c_str());
         }
     }
 

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -1,5 +1,6 @@
 #include "vm.h"
 #include "debug.h"
+#include "function.h"
 #include "memory_manager.h"
 #include "object.h"
 #include "scanner.h"
@@ -13,17 +14,17 @@
 #include <unistd.h>
 
 InterpretResult VM::interpret(const std::string& source) {
-    auto chunk = compile(source, &m_mm);
-    if (chunk == nullptr) {
+    ObjFunction* fn = compile(source, &m_mm);
+    if (fn == nullptr) {
         return InterpretResult::COMPILE_ERROR;
     }
 
-    m_chunk = chunk.get();
-    m_ip = m_chunk->cbegin();
+    push(Value{static_cast<Obj*>(fn)});
+    call(fn, 0);
     return run();
 }
 
-Byte VM::readByte() { return *m_ip++; }
+Byte VM::readByte() { return *m_frames[m_frameCount - 1].ip++; }
 
 uint16_t VM::readShort() {
     uint16_t hi = readByte();
@@ -31,7 +32,9 @@ uint16_t VM::readShort() {
     return static_cast<uint16_t>((hi << 8) | lo);
 }
 
-Value VM::readConstant() { return m_chunk->getConstant(readByte()); }
+Value VM::readConstant() {
+    return m_frames[m_frameCount - 1].function->chunk.getConstant(readByte());
+}
 
 Value VM::lastResult() const { return m_lastResult; }
 
@@ -43,6 +46,22 @@ std::optional<Value> VM::getGlobal(const std::string& name) const {
     if (!m_globals.get(key, out))
         return std::nullopt;
     return out;
+}
+
+bool VM::call(ObjFunction* fn, int argCount) {
+    if (argCount != fn->arity) {
+        runtimeError("Expected %d arguments but got %d.", fn->arity, argCount);
+        return false;
+    }
+    if (m_frameCount == FRAMES_MAX) {
+        runtimeError("Stack overflow.");
+        return false;
+    }
+    CallFrame* frame = &m_frames[m_frameCount++];
+    frame->function = fn;
+    frame->ip = fn->chunk.cbegin();
+    frame->slots = stackTop - argCount - 1;
+    return true;
 }
 
 InterpretResult VM::run() {
@@ -57,19 +76,25 @@ InterpretResult VM::run() {
         push(as<valueType>(a op b));                                           \
     } while (false)
 
+    CallFrame* frame = &m_frames[m_frameCount - 1];
+
     for (;;) {
 #ifdef LOXPP_DEBUG_TRACE_EXECUTION
-        int currentOffset = static_cast<int>(m_ip - m_chunk->cbegin());
-        bool color = isatty(STDOUT_FILENO) != 0;
-        std::printf("[line %d] ", m_chunk->getLine(currentOffset));
-        std::printf("          ");
-        for (Value* slot = stack; slot < stackTop; slot++) {
-            std::printf("[ ");
-            printValue(*slot);
-            std::printf(" ]");
+        {
+            const Chunk& chunk = frame->function->chunk;
+            int currentOffset = static_cast<int>(frame->ip - chunk.cbegin());
+            bool color = isatty(STDOUT_FILENO) != 0;
+            std::printf("[line %d] ", chunk.getLine(currentOffset));
+            std::printf("          ");
+            for (Value* slot = stack; slot < stackTop; slot++) {
+                std::printf("[ ");
+                printValue(*slot);
+                std::printf(" ]");
+            }
+            std::printf("\n");
+            disassembleInstruction(chunk, m_mm, currentOffset, std::cout,
+                                   color);
         }
-        std::printf("\n");
-        disassembleInstruction(*m_chunk, m_mm, currentOffset, std::cout, color);
 #endif
 
         Byte instruction = readByte();
@@ -154,13 +179,13 @@ InterpretResult VM::run() {
         }
         case Op::GET_LOCAL: {
             uint8_t slot = readByte();
-            push(stack[slot]);
+            push(frame->slots[slot]);
             break;
         }
         case Op::SET_LOCAL: {
             uint8_t slot = readByte();
-            stack[slot] =
-                peek(0); // assignment is an expression; leave value on stack
+            // assignment is an expression; leave value on stack
+            frame->slots[slot] = peek(0);
             break;
         }
         case Op::DEFINE_GLOBAL: {
@@ -181,8 +206,9 @@ InterpretResult VM::run() {
         }
         case Op::SET_GLOBAL: {
             ObjString* name = asObjString(readConstant());
-            // set() returns true if the key is *new*; an existing key is valid.
-            // An entirely new key means the variable was never declared.
+            // set() returns true if the key is *new*; an existing key is
+            // valid. An entirely new key means the variable was never
+            // declared.
             if (m_globals.set(name, peek(0))) {
                 m_globals.del(name); // undo the spurious insertion
                 runtimeError("Undefined variable '%s'.", name->chars.c_str());
@@ -191,21 +217,45 @@ InterpretResult VM::run() {
             break;
         }
         case Op::JUMP: {
-            m_ip += readShort();
+            frame->ip += readShort();
             break;
         }
         case Op::JUMP_IF_FALSE: {
             uint16_t offset = readShort();
             if (isFalsy(peek(0)))
-                m_ip += offset;
+                frame->ip += offset;
             break;
         }
         case Op::LOOP: {
-            m_ip -= readShort();
+            frame->ip -= readShort();
+            break;
+        }
+        case Op::CALL: {
+            int argCount = readByte();
+            Value callee = peek(argCount);
+            if (!isFunction(callee)) {
+                runtimeError("Can only call functions and classes.");
+                return InterpretResult::RUNTIME_ERROR;
+            }
+            if (!call(asObjFunction(callee), argCount)) {
+                return InterpretResult::RUNTIME_ERROR;
+            }
+            frame = &m_frames[m_frameCount - 1];
             break;
         }
         case Op::RETURN: {
-            return InterpretResult::OK;
+            Value result = pop();
+            m_frameCount--;
+            if (m_frameCount == 0) {
+                // Finished executing the top-level script.
+                pop(); // remove the script ObjFunction from the stack
+                return InterpretResult::OK;
+            }
+            // Discard the callee's stack window and push return value.
+            stackTop = frame->slots;
+            push(result);
+            frame = &m_frames[m_frameCount - 1];
+            break;
         }
         }
     }
@@ -221,13 +271,27 @@ void VM::runtimeError(const char* format, ...) {
     va_end(args);
     std::fputs("\n", stderr);
 
-    auto instruction = m_ip - m_chunk->cbegin() - 1;
-    int line = m_chunk->getLine(instruction);
-    std::fprintf(stderr, "[line %d] in script\n", line);
+    // Print a stack trace (innermost frame first).
+    for (int i = m_frameCount - 1; i >= 0; i--) {
+        const CallFrame& f = m_frames[i];
+        const Chunk& chunk = f.function->chunk;
+        auto offset = static_cast<int>(f.ip - chunk.cbegin()) - 1;
+        int line = chunk.getLine(offset);
+        std::fprintf(stderr, "[line %d] in ", line);
+        if (f.function->name == nullptr) {
+            std::fprintf(stderr, "script\n");
+        } else {
+            std::fprintf(stderr, "%s()\n", f.function->name->chars.c_str());
+        }
+    }
+
     resetStack();
 }
 
-void VM::resetStack() { stackTop = stack; }
+void VM::resetStack() {
+    stackTop = stack;
+    m_frameCount = 0;
+}
 
 void VM::push(Value value) { *stackTop++ = value; }
 

--- a/src/vm.h
+++ b/src/vm.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "chunk.h"
+#include "function.h"
 #include "memory_manager.h"
 #include "table.h"
 
@@ -14,9 +14,16 @@ enum class InterpretResult {
     RUNTIME_ERROR,
 };
 
+struct CallFrame {
+    ObjFunction* function;
+    Chunk::const_iterator ip;
+    Value* slots; // points into the VM stack at this frame's base slot
+};
+
 class VM {
   public:
     static constexpr int STACK_MAX = 256;
+    static constexpr int FRAMES_MAX = 64;
 
     VM() : m_globals(VmAllocator<Entry>{&m_mm}) { resetStack(); }
 
@@ -26,6 +33,7 @@ class VM {
 
     // Runtime state inspection (for testing and debugging).
     int stackDepth() const { return static_cast<int>(stackTop - stack); }
+    int frameCount() const { return m_frameCount; }
     std::optional<Value> getGlobal(const std::string& name) const;
 
   private:
@@ -37,14 +45,15 @@ class VM {
     Value pop();
     Value peek(int distance);
 
+    bool call(ObjFunction* fn, int argCount);
     void runtimeError(const char* format, ...);
 
-    Chunk const* m_chunk;
-    Chunk::const_iterator m_ip;
+    CallFrame m_frames[FRAMES_MAX];
+    int m_frameCount{0};
     Value stack[STACK_MAX];
     Value* stackTop;
     MemoryManager m_mm;
     Table m_globals;
-    Value m_lastResult; // For testing/debugging only — stores the value popped
-                        // by Op::POP.
+    Value m_lastResult; // For testing/debugging only -- stores the value
+                        // popped by Op::POP.
 };

--- a/test/test_harness.cpp
+++ b/test/test_harness.cpp
@@ -2,6 +2,7 @@
 #include "vm.h"
 #include "compiler.h"
 #include "debug.h"
+#include "function.h"
 #include "memory_manager.h"
 #include <sstream>
 
@@ -23,24 +24,26 @@ std::string eval_expr_str(const std::string& expr) {
 
 std::string compile_to_bytecode(const std::string& expr) {
     MemoryManager mm;
-    auto chunk = compile(expr + ";", &mm);
-    if (!chunk)
+    ObjFunction* fn = compile(expr + ";", &mm);
+    if (!fn)
         throw std::runtime_error("Compilation failed");
     std::ostringstream oss;
-    for (int offset = 0; offset < static_cast<int>(chunk->size());) {
-        offset = disassembleInstruction(*chunk, mm, offset, oss);
+    const Chunk& chunk = fn->chunk;
+    for (int offset = 0; offset < static_cast<int>(chunk.size());) {
+        offset = disassembleInstruction(chunk, mm, offset, oss);
     }
     return oss.str();
 }
 
 std::string compile_program_to_bytecode(const std::string& source) {
     MemoryManager mm;
-    auto chunk = compile(source, &mm);
-    if (!chunk)
+    ObjFunction* fn = compile(source, &mm);
+    if (!fn)
         throw std::runtime_error("Compilation failed");
     std::ostringstream oss;
-    for (int offset = 0; offset < static_cast<int>(chunk->size());) {
-        offset = disassembleInstruction(*chunk, mm, offset, oss);
+    const Chunk& chunk = fn->chunk;
+    for (int offset = 0; offset < static_cast<int>(chunk.size());) {
+        offset = disassembleInstruction(chunk, mm, offset, oss);
     }
     return oss.str();
 }

--- a/test/test_parser_bytecode.cpp
+++ b/test/test_parser_bytecode.cpp
@@ -26,7 +26,8 @@ TEST_F(ParserBytecodeTest, Arithmetic_Addition) {
                            "2: CONSTANT 1 ('2')\n"
                            "4: ADD\n"
                            "5: POP\n"
-                           "6: RETURN\n";
+                           "6: NIL\n"
+                           "7: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -39,7 +40,8 @@ TEST_F(ParserBytecodeTest, Arithmetic_MultiplySubtract) {
                            "5: CONSTANT 2 ('5')\n"
                            "7: SUBTRACT\n"
                            "8: POP\n"
-                           "9: RETURN\n";
+                           "9: NIL\n"
+                           "10: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -51,7 +53,8 @@ TEST_F(ParserBytecodeTest, Comparison_Equal) {
                            "2: CONSTANT 0 ('1')\n"
                            "4: EQUAL\n"
                            "5: POP\n"
-                           "6: RETURN\n";
+                           "6: NIL\n"
+                           "7: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -64,7 +67,8 @@ TEST_F(ParserBytecodeTest, Comparison_LessGreater) {
                            "5: CONSTANT 2 ('1')\n"
                            "7: GREATER\n"
                            "8: POP\n"
-                           "9: RETURN\n";
+                           "9: NIL\n"
+                           "10: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -76,7 +80,8 @@ TEST_F(ParserBytecodeTest, Boolean_TrueFalseNot) {
                            "2: TRUE\n"
                            "3: EQUAL\n"
                            "4: POP\n"
-                           "5: RETURN\n";
+                           "5: NIL\n"
+                           "6: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -87,7 +92,8 @@ TEST_F(ParserBytecodeTest, String_Concatenation) {
                            "2: CONSTANT 1 ('bar')\n"
                            "4: ADD\n"
                            "5: POP\n"
-                           "6: RETURN\n";
+                           "6: NIL\n"
+                           "7: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -99,7 +105,8 @@ TEST_F(ParserBytecodeTest, GroupingAndNegate) {
                            "4: ADD\n"
                            "5: NEGATE\n"
                            "6: POP\n"
-                           "7: RETURN\n";
+                           "7: NIL\n"
+                           "8: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -108,7 +115,8 @@ TEST_F(ParserBytecodeTest, NilLiteral) {
     std::string bytecode = compile_to_bytecode(expr);
     std::string expected = "0: NIL\n"
                            "1: POP\n"
-                           "2: RETURN\n";
+                           "2: NIL\n"
+                           "3: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -133,6 +141,7 @@ TEST_F(ParserBytecodeTest, Dedup_SameVariableReusesConstantSlot) {
                            "8: ADD\n"
                            "9: SET_GLOBAL 1 ('x')\n" // x reuses slot 1
                            "11: POP\n"
-                           "12: RETURN\n";
+                           "12: NIL\n"
+                           "13: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }

--- a/test/test_vm_runtime.cpp
+++ b/test/test_vm_runtime.cpp
@@ -270,3 +270,56 @@ TEST_F(CompileErrorTest, TooManyConstants) {
     VMTestHarness h;
     EXPECT_EQ(h.run(source), InterpretResult::COMPILE_ERROR);
 }
+
+// ===========================================================================
+// Call frame tests
+// ===========================================================================
+// These tests verify the VM's call frame machinery via Op::CALL. Since there
+// is no function declaration syntax yet, we exercise Op::CALL by calling
+// non-function values (which must produce a runtime error) and verify that
+// the stack is clean afterwards.
+
+class CallFrameTest : public ::testing::Test {};
+
+// Calling a number must produce a runtime error.
+TEST_F(CallFrameTest, CallNumberIsRuntimeError) {
+    VMTestHarness h;
+    EXPECT_EQ(h.run("var x = 42;\nx();"), InterpretResult::RUNTIME_ERROR);
+}
+
+// Calling nil must produce a runtime error.
+TEST_F(CallFrameTest, CallNilIsRuntimeError) {
+    VMTestHarness h;
+    EXPECT_EQ(h.run("nil();"), InterpretResult::RUNTIME_ERROR);
+}
+
+// Calling a boolean must produce a runtime error.
+TEST_F(CallFrameTest, CallBoolIsRuntimeError) {
+    VMTestHarness h;
+    EXPECT_EQ(h.run("true();"), InterpretResult::RUNTIME_ERROR);
+}
+
+// Calling a string must produce a runtime error.
+TEST_F(CallFrameTest, CallStringIsRuntimeError) {
+    VMTestHarness h;
+    EXPECT_EQ(h.run("\"hello\"();"), InterpretResult::RUNTIME_ERROR);
+}
+
+// Stack must be empty after a runtime error during a call attempt.
+TEST_F(CallFrameTest, StackCleanAfterCallError) {
+    VMTestHarness h;
+    EXPECT_EQ(h.run("nil();"), InterpretResult::RUNTIME_ERROR);
+    EXPECT_EQ(h.stackDepth(), 0);
+}
+
+// A call with arguments on a non-function is still a runtime error.
+TEST_F(CallFrameTest, CallNilWithArgsIsRuntimeError) {
+    VMTestHarness h;
+    EXPECT_EQ(h.run("nil(1, 2, 3);"), InterpretResult::RUNTIME_ERROR);
+}
+
+// Calling a computed expression that yields a non-function is an error.
+TEST_F(CallFrameTest, CallExpressionResultIsRuntimeError) {
+    VMTestHarness h;
+    EXPECT_EQ(h.run("(1 + 2)();"), InterpretResult::RUNTIME_ERROR);
+}


### PR DESCRIPTION
## Summary

Lays the runtime foundation for functions. No `fun` declaration parsing yet — that comes next. But the runtime is now fully capable of multi-frame execution.

## What changed

### New file: `src/function.h`
- `ObjFunction` struct owns its `Chunk`, `arity`, and `ObjString* name`
- Lives in a separate header to avoid the `object.h ← value.h ← chunk.h` circular include

### Object system
- `ObjType::FUNCTION` added to the enum
- `stringifyObj` prints `<script>` or `<fn name>`
- `isFunction()` helper added to `value.h`

### Compiler (`compiler.h/cpp`)
- `compile()` now returns `ObjFunction*` instead of `unique_ptr<Chunk>`
- `Compiler` targets an `ObjFunction`; constructor reserves slot 0 for the callee so user locals start at slot 1 (consistent with future `fun` support)
- `emitReturn()` now emits `NIL; RETURN` — always a value to pop on frame exit
- New `call()` parselet compiles `expr(args)` → `Op::CALL argCount`

### Parser (`parser.cpp`)
- `LEFT_PAREN` infix registered to `&Compiler::call`, enabling call-expression syntax

### VM (`vm.h/vm.cpp`)
- Added `CallFrame { function, ip, slots }` and `frames[64]`
- `GET_LOCAL`/`SET_LOCAL` are now frame-relative via `frame->slots`
- `Op::CALL` pushes a new frame (with arity check); `Op::RETURN` pops it or exits cleanly at frame 0
- `runtimeError()` prints a full stack trace

### Debug (`debug.cpp`)
- `Op::CALL` disassembled as `byteInstruction`

## Tests
- All 9 existing test suites pass (regression)
- 9 bytecode tests updated for the new `NIL` before `RETURN`
- 7 new `CallFrameTest` cases: calling nil, number, bool, string, or a computed non-function expression → `RUNTIME_ERROR` with `stackDepth() == 0`