### PR TITLE
feat: add fun declaration and return statement

### DIFF
--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -10,7 +10,8 @@
 ObjFunction* compile(const std::string& source, MemoryManager* mm) {
     ObjFunction* fn = mm->create<ObjFunction>();
     auto parser = std::make_unique<Parser>(source);
-    auto compiler = std::make_unique<Compiler>(fn, parser.get(), mm);
+    auto compiler = std::make_unique<Compiler>(fn, parser.get(), mm,
+                                               FunctionType::SCRIPT, nullptr);
 
     while (!parser->check(TokenType::EOF_))
         compiler->declaration();
@@ -22,8 +23,10 @@ ObjFunction* compile(const std::string& source, MemoryManager* mm) {
     return fn;
 }
 
-Compiler::Compiler(ObjFunction* function, Parser* parser, MemoryManager* mm)
-    : m_function{function}, m_parser{parser}, m_mm{mm} {
+Compiler::Compiler(ObjFunction* function, Parser* parser, MemoryManager* mm,
+                   FunctionType type, Compiler* enclosing)
+    : m_function{function}, m_parser{parser}, m_mm{mm}, m_type{type},
+      m_enclosing{enclosing} {
     // Reserve slot 0 for the function/script itself. User-declared locals
     // start at slot 1. The implicit local has an empty name so resolveLocal
     // never accidentally matches it.
@@ -166,7 +169,9 @@ void Compiler::call() {
 }
 
 void Compiler::declaration() {
-    if (m_parser->match(TokenType::VAR)) {
+    if (m_parser->match(TokenType::FUN)) {
+        funDeclaration();
+    } else if (m_parser->match(TokenType::VAR)) {
         varDeclaration();
     } else {
         statement();
@@ -274,6 +279,8 @@ void Compiler::statement() {
         continueStatement();
     } else if (m_parser->match(TokenType::PRINT)) {
         printStatement();
+    } else if (m_parser->match(TokenType::RETURN)) {
+        returnStatement();
     } else {
         expressionStatement();
     }
@@ -402,6 +409,66 @@ void Compiler::continueStatement() {
     m_parser->consume(TokenType::SEMICOLON, "Expect ';' after 'continue'.");
     emitLoopCleanup();
     emitLoop(m_loopStack.back().start);
+}
+
+void Compiler::funDeclaration() {
+    m_parser->consume(TokenType::IDENTIFIER, "Expect function name.");
+    Token name = m_parser->m_previous;
+
+    uint8_t nameConst = 0;
+    if (m_scopeDepth > 0) {
+        declareVariable();
+        markInitialized(); // allow recursion inside the body
+    } else {
+        nameConst = identifierConstant(name);
+    }
+
+    ObjFunction* fn = m_mm->create<ObjFunction>();
+    fn->name = m_mm->makeString(name.lexeme);
+
+    Compiler inner(fn, m_parser, m_mm, FunctionType::FUNCTION, this);
+    inner.parseFunction(FunctionType::FUNCTION);
+
+    emitBytes(Op::CONSTANT, makeConstant(Value{static_cast<Obj*>(fn)}));
+    if (m_scopeDepth == 0) {
+        emitBytes(Op::DEFINE_GLOBAL, nameConst);
+    }
+}
+
+void Compiler::returnStatement() {
+    if (m_type == FunctionType::SCRIPT) {
+        m_parser->error("Can't return from top-level code.");
+        return;
+    }
+    if (m_parser->match(TokenType::SEMICOLON)) {
+        emitReturn();
+    } else {
+        expression();
+        m_parser->consume(TokenType::SEMICOLON,
+                          "Expect ';' after return value.");
+        emitByte(Op::RETURN);
+    }
+}
+
+void Compiler::parseFunction(FunctionType type) {
+    (void)type; // reserved for future use (e.g. methods vs. functions)
+    beginScope();
+    m_parser->consume(TokenType::LEFT_PAREN, "Expect '(' after function name.");
+    if (!m_parser->check(TokenType::RIGHT_PAREN)) {
+        do {
+            m_function->arity++;
+            if (m_function->arity > 255)
+                m_parser->error("Can't have more than 255 parameters.");
+            m_parser->consume(TokenType::IDENTIFIER, "Expect parameter name.");
+            declareVariable();
+            markInitialized();
+        } while (m_parser->match(TokenType::COMMA));
+    }
+    m_parser->consume(TokenType::RIGHT_PAREN, "Expect ')' after parameters.");
+    m_parser->consume(TokenType::LEFT_BRACE,
+                      "Expect '{' before function body.");
+    block();
+    endCompiler();
 }
 
 void Compiler::and_() {

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -8,10 +8,13 @@
 #include <vector>
 
 class MemoryManager;
+class Compiler;
 
 static constexpr int UINT8_COUNT = 256;
 
 ObjFunction* compile(const std::string& source, MemoryManager* mm);
+
+enum class FunctionType { SCRIPT, FUNCTION };
 
 struct Local {
     Token name;
@@ -27,7 +30,9 @@ struct LoopContext {
 
 class Compiler {
   public:
-    Compiler(ObjFunction* function, Parser* parser, MemoryManager* mm);
+    Compiler(ObjFunction* function, Parser* parser, MemoryManager* mm,
+             FunctionType type = FunctionType::SCRIPT,
+             Compiler* enclosing = nullptr);
 
     Chunk* getCurrentChunk() const { return &m_function->chunk; }
     void endCompiler();
@@ -53,6 +58,8 @@ class Compiler {
     void continueStatement();
     void varDeclaration();
     void block();
+    void funDeclaration();
+    void returnStatement();
 
     void and_();
     void or_();
@@ -65,6 +72,8 @@ class Compiler {
     int resolveLocal(const Token& name) const;
     void declareVariable();
     void markInitialized();
+
+    void parseFunction(FunctionType type);
 
     void emitByte(Byte byte);
     void emitByte(Op op);
@@ -82,6 +91,8 @@ class Compiler {
     ObjFunction* m_function;
     Parser* m_parser;
     MemoryManager* m_mm;
+    FunctionType m_type;
+    Compiler* m_enclosing;
 
     Local m_locals[UINT8_COUNT];
     int m_localCount{0};

--- a/test/test_harness.cpp
+++ b/test/test_harness.cpp
@@ -4,6 +4,7 @@
 #include "debug.h"
 #include "function.h"
 #include "memory_manager.h"
+#include "object.h"
 #include <sstream>
 
 Value eval_expr(const std::string& expr) {
@@ -51,6 +52,44 @@ std::string compile_program_to_bytecode(const std::string& source) {
 InterpretResult run_program(const std::string& source) {
     VM vm;
     return vm.interpret(source);
+}
+
+// ---------------------------------------------------------------------------
+// compile_fn_body_to_bytecode
+// ---------------------------------------------------------------------------
+
+std::string compile_fn_body_to_bytecode(const std::string& source, int n) {
+    MemoryManager mm;
+    ObjFunction* script = compile(source, &mm);
+    if (!script)
+        throw std::runtime_error("Compilation failed");
+
+    int found = 0;
+    const Chunk& scriptChunk = script->chunk;
+    for (int i = 0; i < static_cast<int>(scriptChunk.size());) {
+        Byte op = scriptChunk.at(i);
+        if (toOpcode(op) == Op::CONSTANT) {
+            uint8_t idx = scriptChunk.at(i + 1);
+            Value v = scriptChunk.getConstant(idx);
+            if (is<Obj*>(v) && isObjType(as<Obj*>(v), ObjType::FUNCTION)) {
+                if (found == n) {
+                    ObjFunction* fn = asObjFunction(v);
+                    std::ostringstream oss;
+                    const Chunk& chunk = fn->chunk;
+                    for (int offset = 0;
+                         offset < static_cast<int>(chunk.size());) {
+                        offset = disassembleInstruction(chunk, mm, offset, oss);
+                    }
+                    return oss.str();
+                }
+                found++;
+            }
+            i += 2;
+        } else {
+            i++;
+        }
+    }
+    throw std::runtime_error("Not enough inner functions found");
 }
 
 // ---------------------------------------------------------------------------

--- a/test/test_harness.cpp
+++ b/test/test_harness.cpp
@@ -55,33 +55,21 @@ InterpretResult run_program(const std::string& source) {
 }
 
 // ---------------------------------------------------------------------------
-// compile_fn_body_to_bytecode
+// Inner-function helpers
 // ---------------------------------------------------------------------------
 
-std::string compile_fn_body_to_bytecode(const std::string& source, int n) {
-    MemoryManager mm;
-    ObjFunction* script = compile(source, &mm);
-    if (!script)
-        throw std::runtime_error("Compilation failed");
-
+// Stage 1: scan the script chunk's constant pool for ObjFunction values,
+// return the Nth one (0-indexed).
+ObjFunction* find_inner_function(ObjFunction* script, int n) {
     int found = 0;
-    const Chunk& scriptChunk = script->chunk;
-    for (int i = 0; i < static_cast<int>(scriptChunk.size());) {
-        Byte op = scriptChunk.at(i);
-        if (toOpcode(op) == Op::CONSTANT) {
-            uint8_t idx = scriptChunk.at(i + 1);
-            Value v = scriptChunk.getConstant(idx);
+    const Chunk& chunk = script->chunk;
+    for (int i = 0; i < static_cast<int>(chunk.size());) {
+        if (toOpcode(chunk.at(i)) == Op::CONSTANT) {
+            uint8_t idx = chunk.at(i + 1);
+            Value v = chunk.getConstant(idx);
             if (is<Obj*>(v) && isObjType(as<Obj*>(v), ObjType::FUNCTION)) {
-                if (found == n) {
-                    ObjFunction* fn = asObjFunction(v);
-                    std::ostringstream oss;
-                    const Chunk& chunk = fn->chunk;
-                    for (int offset = 0;
-                         offset < static_cast<int>(chunk.size());) {
-                        offset = disassembleInstruction(chunk, mm, offset, oss);
-                    }
-                    return oss.str();
-                }
+                if (found == n)
+                    return asObjFunction(v);
                 found++;
             }
             i += 2;
@@ -90,6 +78,24 @@ std::string compile_fn_body_to_bytecode(const std::string& source, int n) {
         }
     }
     throw std::runtime_error("Not enough inner functions found");
+}
+
+// Stage 2: disassemble every instruction in a chunk into a readable string.
+std::string disassemble_chunk(const Chunk& chunk, MemoryManager& mm) {
+    std::ostringstream oss;
+    for (int offset = 0; offset < static_cast<int>(chunk.size());)
+        offset = disassembleInstruction(chunk, mm, offset, oss);
+    return oss.str();
+}
+
+// Convenience wrapper: compile → find → disassemble.
+std::string compile_fn_body_to_bytecode(const std::string& source, int n) {
+    MemoryManager mm;
+    ObjFunction* script = compile(source, &mm);
+    if (!script)
+        throw std::runtime_error("Compilation failed");
+    ObjFunction* fn = find_inner_function(script, n);
+    return disassemble_chunk(fn->chunk, mm);
 }
 
 // ---------------------------------------------------------------------------

--- a/test/test_harness.h
+++ b/test/test_harness.h
@@ -30,6 +30,11 @@ std::string compile_program_to_bytecode(const std::string& source);
 // result. Use for multi-statement programs where only pass/fail matters.
 InterpretResult run_program(const std::string& source);
 
+// Compiles a Lox++ program and returns the bytecode of the Nth inner
+// ObjFunction constant found in the top-level script chunk (0-indexed).
+// Throws if there are fewer than (n+1) function constants.
+std::string compile_fn_body_to_bytecode(const std::string& source, int n = 0);
+
 // ---------------------------------------------------------------------------
 // VMTestHarness — wraps VM and exposes runtime state for invariant testing
 // ---------------------------------------------------------------------------

--- a/test/test_harness.h
+++ b/test/test_harness.h
@@ -30,9 +30,15 @@ std::string compile_program_to_bytecode(const std::string& source);
 // result. Use for multi-statement programs where only pass/fail matters.
 InterpretResult run_program(const std::string& source);
 
-// Compiles a Lox++ program and returns the bytecode of the Nth inner
-// ObjFunction constant found in the top-level script chunk (0-indexed).
-// Throws if there are fewer than (n+1) function constants.
+// Stage 1: compile source, return the Nth ObjFunction constant found in the
+// top-level script chunk (0-indexed). Throws if fewer than (n+1) exist.
+// Pass the MemoryManager used to compile so it owns the returned pointer.
+ObjFunction* find_inner_function(ObjFunction* script, int n = 0);
+
+// Stage 2: return a readable disassembly string for a compiled chunk.
+std::string disassemble_chunk(const Chunk& chunk, MemoryManager& mm);
+
+// Convenience: compile source, find the Nth inner function, disassemble it.
 std::string compile_fn_body_to_bytecode(const std::string& source, int n = 0);
 
 // ---------------------------------------------------------------------------

--- a/test/test_parser_bytecode.cpp
+++ b/test/test_parser_bytecode.cpp
@@ -145,3 +145,67 @@ TEST_F(ParserBytecodeTest, Dedup_SameVariableReusesConstantSlot) {
                            "13: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
+
+// ===========================================================================
+// Function declaration bytecode tests
+// ===========================================================================
+
+class FunctionBytecodeTest : public ::testing::Test {};
+
+// fun foo() {} — empty body, no params.
+// Outer (script) chunk: CONSTANT(<fn foo>) + DEFINE_GLOBAL('foo') + NIL+RETURN
+// Inner (foo) chunk: NIL + RETURN (from emitReturn())
+TEST_F(FunctionBytecodeTest, EmptyFunction_OuterChunk) {
+    // Constant 0 = 'foo' (global name), constant 1 = <fn foo>
+    std::string bytecode = compile_program_to_bytecode("fun foo() {}");
+    std::string expected = "0: CONSTANT 1 ('<fn foo>')\n"
+                           "2: DEFINE_GLOBAL 0 ('foo')\n"
+                           "4: NIL\n"
+                           "5: RETURN\n";
+    EXPECT_EQ(trim(bytecode), trim(expected));
+}
+
+TEST_F(FunctionBytecodeTest, EmptyFunction_InnerChunk) {
+    std::string bytecode = compile_fn_body_to_bytecode("fun foo() {}");
+    std::string expected = "0: NIL\n"
+                           "1: RETURN\n";
+    EXPECT_EQ(trim(bytecode), trim(expected));
+}
+
+// fun add(a, b) { return a + b; }
+// Inner chunk: GET_LOCAL 1 (a), GET_LOCAL 2 (b), ADD, RETURN, NIL, RETURN
+// (The NIL+RETURN at the end is dead code emitted by endCompiler().)
+TEST_F(FunctionBytecodeTest, FunctionWithParams_InnerChunk) {
+    std::string src = "fun add(a, b) { return a + b; }";
+    std::string bytecode = compile_fn_body_to_bytecode(src);
+    std::string expected = "0: GET_LOCAL 1\n" // a — slot 1 (slot 0 = fn)
+                           "2: GET_LOCAL 2\n" // b — slot 2
+                           "4: ADD\n"
+                           "5: RETURN\n"
+                           "6: NIL\n" // dead code from endCompiler()
+                           "7: RETURN\n";
+    EXPECT_EQ(trim(bytecode), trim(expected));
+}
+
+// fun id(x) { return x; } — single param, return it
+TEST_F(FunctionBytecodeTest, FunctionSingleParam_InnerChunk) {
+    std::string src = "fun id(x) { return x; }";
+    std::string bytecode = compile_fn_body_to_bytecode(src);
+    std::string expected = "0: GET_LOCAL 1\n"
+                           "2: RETURN\n"
+                           "3: NIL\n"
+                           "4: RETURN\n";
+    EXPECT_EQ(trim(bytecode), trim(expected));
+}
+
+// fun noReturn() { var x = 1; } — no explicit return; body local is NOT
+// explicitly POPped: RETURN resets stackTop to frame->slots, cleaning the
+// frame in one shot. No endScope() is called for the outermost function scope.
+TEST_F(FunctionBytecodeTest, FunctionWithLocalVar_InnerChunk) {
+    std::string src = "fun noReturn() { var x = 1; }";
+    std::string bytecode = compile_fn_body_to_bytecode(src);
+    std::string expected = "0: CONSTANT 0 ('1')\n"
+                           "2: NIL\n"
+                           "3: RETURN\n";
+    EXPECT_EQ(trim(bytecode), trim(expected));
+}

--- a/test/test_vm_runtime.cpp
+++ b/test/test_vm_runtime.cpp
@@ -323,3 +323,94 @@ TEST_F(CallFrameTest, CallExpressionResultIsRuntimeError) {
     VMTestHarness h;
     EXPECT_EQ(h.run("(1 + 2)();"), InterpretResult::RUNTIME_ERROR);
 }
+
+// ===========================================================================
+// Function declaration and call tests
+// ===========================================================================
+
+class FunctionTest : public ::testing::Test {};
+
+// A function with no explicit return returns nil.
+TEST_F(FunctionTest, NoExplicitReturn_ReturnsNil) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("fun f() {} f();"), InterpretResult::OK);
+    EXPECT_EQ(h.lastResult(), from<Nil>(Nil{}));
+}
+
+// A function can return a string literal.
+TEST_F(FunctionTest, ReturnStringLiteral) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("fun greet() { return \"hello\"; } greet();"),
+              InterpretResult::OK);
+    EXPECT_EQ(stringify(h.lastResult()), "hello");
+}
+
+// A function can return a computed value.
+TEST_F(FunctionTest, ReturnComputedValue) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("fun add(a, b) { return a + b; } add(2, 3);"),
+              InterpretResult::OK);
+    EXPECT_EQ(h.lastResult(), from<Number>(5.0));
+}
+
+// Calling a function with too few arguments is a runtime error.
+TEST_F(FunctionTest, TooFewArguments_RuntimeError) {
+    VMTestHarness h;
+    EXPECT_EQ(h.run("fun f(x) {} f();"), InterpretResult::RUNTIME_ERROR);
+}
+
+// Calling a function with too many arguments is a runtime error.
+TEST_F(FunctionTest, TooManyArguments_RuntimeError) {
+    VMTestHarness h;
+    EXPECT_EQ(h.run("fun f() {} f(1);"), InterpretResult::RUNTIME_ERROR);
+}
+
+// A function can call itself recursively.
+TEST_F(FunctionTest, Recursion) {
+    VMTestHarness h;
+    std::string src = "fun count(n) {"
+                      "  if (n <= 0) return 0;"
+                      "  return count(n - 1) + 1;"
+                      "}"
+                      "count(5);";
+    ASSERT_EQ(h.run(src), InterpretResult::OK);
+    EXPECT_EQ(h.lastResult(), from<Number>(5.0));
+}
+
+// Two mutually independent functions can coexist.
+TEST_F(FunctionTest, TwoFunctions) {
+    VMTestHarness h;
+    std::string src = "fun double(x) { return x * 2; }"
+                      "fun triple(x) { return x * 3; }"
+                      "double(3) + triple(2);";
+    ASSERT_EQ(h.run(src), InterpretResult::OK);
+    EXPECT_EQ(h.lastResult(), from<Number>(12.0));
+}
+
+// return at the top level is a compile error.
+TEST_F(FunctionTest, ReturnAtTopLevel_CompileError) {
+    VMTestHarness h;
+    EXPECT_EQ(h.run("return 1;"), InterpretResult::COMPILE_ERROR);
+}
+
+// Stack must be empty after a successful function call.
+TEST_F(FunctionTest, StackCleanAfterCall) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("fun f() { return 42; } f();"), InterpretResult::OK);
+    EXPECT_EQ(h.stackDepth(), 0);
+}
+
+// A function defined in a local scope is a local variable.
+// Store the result globally so endScope()'s POP of `square` doesn't
+// overwrite lastResult().
+TEST_F(FunctionTest, LocalFunction) {
+    VMTestHarness h;
+    std::string src = "var r = 0;"
+                      "{"
+                      "  fun square(x) { return x * x; }"
+                      "  r = square(4);"
+                      "}"
+                      "r;";
+    ASSERT_EQ(h.run(src), InterpretResult::OK);
+    EXPECT_EQ(h.lastResult(), from<Number>(16.0));
+}


### PR DESCRIPTION
## Summary

Adds `fun` declaration syntax and `return` statement to the frontend, wired into the full compiler → VM pipeline.

### Changes

**`src/compiler.h`**
- New `FunctionType` enum (`SCRIPT` / `FUNCTION`)
- `Compiler` gains `m_type` and `m_enclosing` members
- Updated constructor signature; new `funDeclaration()`, `returnStatement()`, `parseFunction()` methods

**`src/compiler.cpp`**
- `funDeclaration()`: parses `fun <name>(<params>) { <body> }` at any declaration site (global or local scope); creates a nested `Compiler` for the body; emits `Op::CONSTANT` + optional `Op::DEFINE_GLOBAL`
- `parseFunction()`: called on inner compiler; `beginScope()` so params live at depth 1; no `endScope()` — `RETURN` resets the frame; delegates to `block()` + `endCompiler()`
- `returnStatement()`: compile error at top level; `return;` → NIL+RETURN; `return <expr>;` → expr+RETURN
- `declaration()` dispatches on `TokenType::FUN`; `statement()` dispatches on `TokenType::RETURN`

**Tests**
- `compile_fn_body_to_bytecode()` helper in `test_harness` to inspect inner function chunks
- `FunctionBytecodeTest`: empty body, params+return, single param, local var (no explicit POP — RETURN cleans the frame)
- `FunctionTest`: return nil, return value, return with args, arity errors (too few / too many), recursion, two functions, local function, stack-clean invariant, top-level return compile error

### Design notes

- Each function body compiles in its own `Compiler` instance sharing the same `Parser` (single-pass)
- `markInitialized()` is called before compiling the body to allow recursion
- `m_enclosing` is stored for future closure support but not yet used
- Dead code after explicit `return` (the implicit `emitReturn()` NIL+RETURN from `endCompiler()`) is harmless and matches clox behaviour