### PR TITLE
feat: add native C++ functions (clock, input, str)

### DIFF
--- a/src/native.h
+++ b/src/native.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "object.h"
+#include "value.h"
+
+// Signature for all native (C++) functions callable from Lox.
+using NativeFn = Value (*)(int argCount, Value* args);
+
+struct ObjNative : public Obj {
+    NativeFn function;
+    int arity; // expected argument count; -1 = variadic (any count accepted)
+    ObjNative(NativeFn fn, int arity)
+        : Obj(ObjType::NATIVE), function(fn), arity(arity) {}
+};
+
+inline bool isObjNative(Obj* obj) { return isObjType(obj, ObjType::NATIVE); }
+inline ObjNative* asObjNative(Obj* obj) { return static_cast<ObjNative*>(obj); }
+inline ObjNative* asObjNative(const Value& v) {
+    return static_cast<ObjNative*>(as<Obj*>(v));
+}

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -18,6 +18,8 @@ std::string stringifyObj(Obj* obj) {
                std::string(fn->name->chars.data(), fn->name->chars.size()) +
                ">";
     }
+    case ObjType::NATIVE:
+        return "<native fn>";
     }
     return "<obj>";
 }

--- a/src/object.h
+++ b/src/object.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <string_view>
 
-enum class ObjType : uint8_t { STRING, FUNCTION };
+enum class ObjType : uint8_t { STRING, FUNCTION, NATIVE };
 
 inline uint32_t hashString(std::string_view s) {
     uint32_t hash = 2166136261U;

--- a/src/value.h
+++ b/src/value.h
@@ -34,6 +34,9 @@ inline bool isString(const Value& v) {
 inline bool isFunction(const Value& v) {
     return is<Obj*>(v) && as<Obj*>(v)->type == ObjType::FUNCTION;
 }
+inline bool isNative(const Value& v) {
+    return is<Obj*>(v) && as<Obj*>(v)->type == ObjType::NATIVE;
+}
 inline Obj* asObj(const Value& v) { return as<Obj*>(v); }
 inline ObjString* asObjString(const Value& v) {
     return static_cast<ObjString*>(as<Obj*>(v));

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -2,16 +2,45 @@
 #include "debug.h"
 #include "function.h"
 #include "memory_manager.h"
+#include "native.h"
 #include "object.h"
 #include "scanner.h"
 #include "compiler.h"
 
 #include <cstdio>
 #include <cstdarg>
+#include <ctime>
 #include <functional>
 #include <iostream>
 #include <string>
 #include <unistd.h>
+
+// ---------------------------------------------------------------------------
+// Native function implementations
+// ---------------------------------------------------------------------------
+
+static Value clockNative(int /*argCount*/, Value* /*args*/) {
+    return from<Number>(static_cast<double>(std::clock()) / CLOCKS_PER_SEC);
+}
+
+// Read one line from stdin. Returns nil on EOF, otherwise an ObjString.
+// The VM pointer is smuggled via a thread-local so native functions can
+// allocate managed strings without changing the NativeFn signature.
+static MemoryManager* s_currentMM = nullptr;
+
+static Value inputNative(int /*argCount*/, Value* /*args*/) {
+    std::string line;
+    if (!std::getline(std::cin, line))
+        return from<Nil>(Nil{});
+    ObjString* s = s_currentMM->makeString(line);
+    return Value{static_cast<Obj*>(s)};
+}
+
+static Value strNative(int /*argCount*/, Value* args) {
+    std::string s = stringify(args[0]);
+    ObjString* obj = s_currentMM->makeString(s);
+    return Value{static_cast<Obj*>(obj)};
+}
 
 InterpretResult VM::interpret(const std::string& source) {
     ObjFunction* fn = compile(source, &m_mm);
@@ -19,6 +48,8 @@ InterpretResult VM::interpret(const std::string& source) {
         return InterpretResult::COMPILE_ERROR;
     }
 
+    defineNatives();
+    s_currentMM = &m_mm;
     push(Value{static_cast<Obj*>(fn)});
     call(fn, 0);
     return run();
@@ -233,14 +264,20 @@ InterpretResult VM::run() {
         case Op::CALL: {
             int argCount = readByte();
             Value callee = peek(argCount);
-            if (!isFunction(callee)) {
+            if (isNative(callee)) {
+                if (!callNative(asObjNative(callee), argCount)) {
+                    return InterpretResult::RUNTIME_ERROR;
+                }
+                frame = &m_frames[m_frameCount - 1];
+            } else if (isFunction(callee)) {
+                if (!call(asObjFunction(callee), argCount)) {
+                    return InterpretResult::RUNTIME_ERROR;
+                }
+                frame = &m_frames[m_frameCount - 1];
+            } else {
                 runtimeError("Can only call functions and classes.");
                 return InterpretResult::RUNTIME_ERROR;
             }
-            if (!call(asObjFunction(callee), argCount)) {
-                return InterpretResult::RUNTIME_ERROR;
-            }
-            frame = &m_frames[m_frameCount - 1];
             break;
         }
         case Op::RETURN: {
@@ -261,6 +298,30 @@ InterpretResult VM::run() {
     }
 
 #undef BINARY_OP
+}
+
+bool VM::callNative(ObjNative* native, int argCount) {
+    if (native->arity != -1 && argCount != native->arity) {
+        runtimeError("Expected %d arguments but got %d.", native->arity,
+                     argCount);
+        return false;
+    }
+    Value result = native->function(argCount, stackTop - argCount);
+    stackTop -= argCount + 1; // pop args + callee
+    push(result);
+    return true;
+}
+
+void VM::defineNative(const char* name, NativeFn fn, int arity) {
+    ObjNative* native = m_mm.create<ObjNative>(fn, arity);
+    ObjString* key = m_mm.makeString(name);
+    m_globals.set(key, Value{static_cast<Obj*>(native)});
+}
+
+void VM::defineNatives() {
+    defineNative("clock", clockNative, 0);
+    defineNative("input", inputNative, 0);
+    defineNative("str", strNative, 1);
 }
 
 void VM::runtimeError(const char* format, ...) {

--- a/src/vm.h
+++ b/src/vm.h
@@ -2,6 +2,7 @@
 
 #include "function.h"
 #include "memory_manager.h"
+#include "native.h"
 #include "table.h"
 
 #include <memory>
@@ -46,6 +47,9 @@ class VM {
     Value peek(int distance);
 
     bool call(ObjFunction* fn, int argCount);
+    bool callNative(ObjNative* native, int argCount);
+    void defineNative(const char* name, NativeFn fn, int arity);
+    void defineNatives();
     void runtimeError(const char* format, ...);
 
     CallFrame m_frames[FRAMES_MAX];

--- a/test/test_vm_runtime.cpp
+++ b/test/test_vm_runtime.cpp
@@ -414,3 +414,118 @@ TEST_F(FunctionTest, LocalFunction) {
     ASSERT_EQ(h.run(src), InterpretResult::OK);
     EXPECT_EQ(h.lastResult(), from<Number>(16.0));
 }
+
+// ===========================================================================
+// Native function tests
+// ===========================================================================
+
+class NativeTest : public ::testing::Test {};
+
+// ---------------------------------------------------------------------------
+// clock()
+// ---------------------------------------------------------------------------
+
+TEST_F(NativeTest, Clock_ReturnsNumber) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("clock();"), InterpretResult::OK);
+    EXPECT_TRUE(is<Number>(h.lastResult()));
+}
+
+TEST_F(NativeTest, Clock_IsNonNegative) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("clock();"), InterpretResult::OK);
+    EXPECT_GE(as<Number>(h.lastResult()), 0.0);
+}
+
+TEST_F(NativeTest, Clock_NonDecreasing) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("var t1 = clock(); var t2 = clock(); t2 - t1;"),
+              InterpretResult::OK);
+    EXPECT_GE(as<Number>(h.lastResult()), 0.0);
+}
+
+TEST_F(NativeTest, Clock_WrongArity_RuntimeError) {
+    VMTestHarness h;
+    EXPECT_EQ(h.run("clock(1);"), InterpretResult::RUNTIME_ERROR);
+}
+
+// ---------------------------------------------------------------------------
+// str()
+// ---------------------------------------------------------------------------
+
+TEST_F(NativeTest, Str_Number) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("str(42);"), InterpretResult::OK);
+    EXPECT_EQ(stringify(h.lastResult()), "42");
+}
+
+TEST_F(NativeTest, Str_NumberDecimal) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("str(3.14);"), InterpretResult::OK);
+    EXPECT_EQ(stringify(h.lastResult()), "3.14");
+}
+
+TEST_F(NativeTest, Str_BoolTrue) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("str(true);"), InterpretResult::OK);
+    EXPECT_EQ(stringify(h.lastResult()), "true");
+}
+
+TEST_F(NativeTest, Str_BoolFalse) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("str(false);"), InterpretResult::OK);
+    EXPECT_EQ(stringify(h.lastResult()), "false");
+}
+
+TEST_F(NativeTest, Str_Nil) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("str(nil);"), InterpretResult::OK);
+    EXPECT_EQ(stringify(h.lastResult()), "nil");
+}
+
+TEST_F(NativeTest, Str_String_IsIdentity) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("str(\"hello\");"), InterpretResult::OK);
+    EXPECT_EQ(stringify(h.lastResult()), "hello");
+}
+
+TEST_F(NativeTest, Str_ResultIsString) {
+    // str() must return an ObjString, not just a printable value.
+    VMTestHarness h;
+    ASSERT_EQ(h.run("str(42);"), InterpretResult::OK);
+    EXPECT_TRUE(isString(h.lastResult()));
+}
+
+TEST_F(NativeTest, Str_WrongArity_TooFew_RuntimeError) {
+    VMTestHarness h;
+    EXPECT_EQ(h.run("str();"), InterpretResult::RUNTIME_ERROR);
+}
+
+TEST_F(NativeTest, Str_WrongArity_TooMany_RuntimeError) {
+    VMTestHarness h;
+    EXPECT_EQ(h.run("str(1, 2);"), InterpretResult::RUNTIME_ERROR);
+}
+
+// ---------------------------------------------------------------------------
+// Behavioural: natives usable in expressions
+// ---------------------------------------------------------------------------
+
+TEST_F(NativeTest, Str_UsableInConcatenation) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("\"value: \" + str(99);"), InterpretResult::OK);
+    EXPECT_EQ(stringify(h.lastResult()), "value: 99");
+}
+
+TEST_F(NativeTest, NativesAreGlobalVariables) {
+    // Natives are just values stored in globals — they can be assigned to
+    // local variables and called through them.
+    VMTestHarness h;
+    ASSERT_EQ(h.run("var s = str; s(7);"), InterpretResult::OK);
+    EXPECT_EQ(stringify(h.lastResult()), "7");
+}
+
+TEST_F(NativeTest, StackCleanAfterNativeCall) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("str(1); str(2); str(3);"), InterpretResult::OK);
+    EXPECT_EQ(h.stackDepth(), 0);
+}


### PR DESCRIPTION
## Summary

Adds native (C++) function support to the VM, plus three built-in natives.

### New type: `ObjNative`

`src/native.h` introduces:
- `NativeFn = Value(*)(int argCount, Value* args)` — signature for all C++ natives
- `ObjNative` — holds a `NativeFn` pointer and an `arity` field (-1 = variadic)

### VM changes

`Op::CALL` now dispatches on `ObjType::NATIVE` **before** `ObjType::FUNCTION`:
- Checks arity (runtime error on mismatch)
- Calls the C++ function directly — **no new `CallFrame`** pushed
- Pops args + callee, pushes return value

`defineNative(name, fn, arity)` creates an `ObjNative`, wraps it as a `Value`, and stores it in `m_globals` — making all natives ordinary global variables that can be aliased and passed around.

### Three built-in natives

| Name | Arity | Description |
|---|---|---|
| `clock()` | 0 | CPU time in seconds (double) |
| `input()` | 0 | Read one line from stdin; returns String or nil on EOF |
| `str(x)` | 1 | Convert any value to its string representation |

`input()` makes interactive scripts practical. `str()` enables string building without relying solely on `print` (e.g. `"x = " + str(x)`).

### Tests

`NativeTest` suite (15 cases): clock returns number / is non-negative / non-decreasing / wrong arity; str with number / float / bool / nil / string / result-is-ObjString / wrong arity; str in concatenation; native aliasing; stack discipline.