### PR TITLE
doc: formal Lox++ language specification

### DIFF
--- a/spec/01-lexical.md
+++ b/spec/01-lexical.md
@@ -79,7 +79,7 @@ names:
 |---|---|
 | `and` | Logical conjunction |
 | `break` | Loop exit |
-| `class` | Reserved; behavior not yet defined |
+| `class` | Class declaration |
 | `continue` | Loop next-iteration |
 | `else` | Alternate branch |
 | `false` | Boolean literal |
@@ -90,8 +90,8 @@ names:
 | `or` | Logical disjunction |
 | `print` | Print statement |
 | `return` | Function return |
-| `super` | Reserved; behavior not yet defined |
-| `this` | Reserved; behavior not yet defined |
+| `super` | Superclass accessor inside a method |
+| `this` | Current instance reference inside a method |
 | `true` | Boolean literal |
 | `var` | Variable declaration |
 | `while` | While loop |

--- a/spec/01-lexical.md
+++ b/spec/01-lexical.md
@@ -1,0 +1,158 @@
+# Lox++ Lexical Grammar
+
+## Source Encoding
+
+Source files are UTF-8 encoded text. The lexer operates on bytes; multi-byte
+UTF-8 sequences are permitted inside string literals and line comments but have
+no special meaning outside them.
+
+---
+
+## Whitespace
+
+The following characters are treated as whitespace and ignored between tokens:
+
+- Space (`U+0020`)
+- Horizontal tab (`U+0009`)
+- Carriage return (`U+000D`)
+- Newline (`U+000A`)
+
+Lox++ has no significant whitespace. Newlines do not terminate statements.
+
+---
+
+## Comments
+
+A line comment begins with `//` and extends to the end of the current line.
+Comments are treated as whitespace — they produce no tokens.
+
+```
+// This entire line is a comment.
+var x = 1; // Inline comment after a statement.
+```
+
+There are no block comments.
+
+---
+
+## Token Categories
+
+### Single-Character Tokens
+
+| Lexeme | Name |
+|---|---|
+| `(` | LEFT_PAREN |
+| `)` | RIGHT_PAREN |
+| `{` | LEFT_BRACE |
+| `}` | RIGHT_BRACE |
+| `,` | COMMA |
+| `.` | DOT |
+| `-` | MINUS |
+| `+` | PLUS |
+| `;` | SEMICOLON |
+| `/` | SLASH |
+| `*` | STAR |
+
+### One-or-Two-Character Tokens
+
+The scanner always prefers the longer match.
+
+| Lexeme | Name |
+|---|---|
+| `!` | BANG |
+| `!=` | BANG_EQUAL |
+| `=` | EQUAL |
+| `==` | EQUAL_EQUAL |
+| `>` | GREATER |
+| `>=` | GREATER_EQUAL |
+| `<` | LESS |
+| `<=` | LESS_EQUAL |
+
+---
+
+## Keywords
+
+The following identifiers are reserved and may not be used as user-defined
+names:
+
+| Keyword | Notes |
+|---|---|
+| `and` | Logical conjunction |
+| `break` | Loop exit |
+| `class` | Reserved; behavior not yet defined |
+| `continue` | Loop next-iteration |
+| `else` | Alternate branch |
+| `false` | Boolean literal |
+| `for` | For loop |
+| `fun` | Function declaration |
+| `if` | Conditional |
+| `nil` | Nil literal |
+| `or` | Logical disjunction |
+| `print` | Print statement |
+| `return` | Function return |
+| `super` | Reserved; behavior not yet defined |
+| `this` | Reserved; behavior not yet defined |
+| `true` | Boolean literal |
+| `var` | Variable declaration |
+| `while` | While loop |
+
+Keywords are matched case-sensitively. `And` and `AND` are identifiers, not
+keywords.
+
+---
+
+## Identifiers
+
+```
+IDENTIFIER ::= ALPHA ( ALPHA | DIGIT )* ;
+ALPHA      ::= [a-zA-Z_] ;
+DIGIT      ::= [0-9] ;
+```
+
+An identifier begins with a letter (`a`–`z`, `A`–`Z`) or underscore (`_`),
+followed by zero or more letters, digits (`0`–`9`), or underscores.
+
+---
+
+## Number Literals
+
+```
+NUMBER ::= DIGIT+ ( "." DIGIT+ )? ;
+```
+
+Numbers are decimal. An optional fractional part is introduced by `.` followed
+by at least one digit. There are no hexadecimal, octal, binary, or exponential
+notations.
+
+All numbers are represented as IEEE 754 double-precision floating point. There
+is no separate integer type.
+
+Examples: `0`, `42`, `3.14`, `1.0`
+
+---
+
+## String Literals
+
+```
+STRING ::= '"' CHARACTER* '"' ;
+```
+
+A string literal is a sequence of characters enclosed in double quotes. The
+token's value is the content between the quotes (the delimiters themselves are
+not part of the value).
+
+Strings may span multiple lines; newlines inside the string are included in
+the value.
+
+An unterminated string (reaching end-of-input before the closing `"`) is a
+static error.
+
+There are currently no recognized escape sequences — each character in the
+source appears literally in the string value.
+
+---
+
+## End of File
+
+`EOF` is a synthetic token produced after all source characters have been
+consumed. The grammar uses `EOF` as the sentinel that ends a program.

--- a/spec/02-syntax.md
+++ b/spec/02-syntax.md
@@ -6,9 +6,13 @@
 program        ::= declaration* EOF ;
 
 (* Declarations *)
-declaration    ::= funDecl
+declaration    ::= classDecl
+                 | funDecl
                  | varDecl
                  | statement ;
+
+classDecl      ::= "class" IDENTIFIER ( "<" IDENTIFIER )? "{" method* "}" ;
+method         ::= IDENTIFIER "(" parameters? ")" block ;
 
 funDecl        ::= "fun" IDENTIFIER "(" parameters? ")" block ;
 parameters     ::= IDENTIFIER ( "," IDENTIFIER )* ;
@@ -51,7 +55,7 @@ block          ::= "{" declaration* "}" ;
 (* Expressions — ordered from lowest to highest precedence *)
 expression     ::= assignment ;
 
-assignment     ::= IDENTIFIER "=" assignment
+assignment     ::= ( call "." IDENTIFIER | IDENTIFIER ) "=" assignment
                  | logicOr ;
 
 logicOr        ::= logicAnd ( "or" logicAnd )* ;
@@ -69,7 +73,7 @@ factor         ::= unary ( ( "/" | "*" ) unary )* ;
 unary          ::= ( "!" | "-" ) unary
                  | call ;
 
-call           ::= primary ( "(" arguments? ")" )* ;
+call           ::= primary ( "(" arguments? ")" | "." IDENTIFIER )* ;
 
 arguments      ::= expression ( "," expression )* ;
 
@@ -79,6 +83,8 @@ primary        ::= "true"
                  | NUMBER
                  | STRING
                  | IDENTIFIER
+                 | "this"
+                 | "super" "." IDENTIFIER
                  | "(" expression ")" ;
 ```
 
@@ -99,7 +105,7 @@ Operators within the same group are left-associative unless noted otherwise.
 | 6 | `+` `-` | Left |
 | 7 | `*` `/` | Left |
 | 8 | `!` `-` (unary) | Right (prefix) |
-| 9 (highest) | `()` (function call) | Left |
+| 9 (highest) | `()` (function call), `.` (property access) | Left |
 
 ---
 
@@ -123,9 +129,9 @@ with an outer `if`, enclose the inner `if` in a block.
 
 ### Assignment
 
-Assignment is an expression, not a statement. The left-hand side must be a
-bare `IDENTIFIER`; complex left-hand-side expressions (e.g., property access)
-are not currently supported. The value of an assignment expression is the
+Assignment is an expression, not a statement. The left-hand side may be a
+bare `IDENTIFIER` (variable set) or a `call "." IDENTIFIER` (property set);
+any other form is a parse error. The value of an assignment expression is the
 assigned value.
 
 ### Function call arguments

--- a/spec/02-syntax.md
+++ b/spec/02-syntax.md
@@ -1,0 +1,134 @@
+# Lox++ Syntax Grammar
+
+## Complete EBNF Grammar
+
+```
+program        ::= declaration* EOF ;
+
+(* Declarations *)
+declaration    ::= funDecl
+                 | varDecl
+                 | statement ;
+
+funDecl        ::= "fun" IDENTIFIER "(" parameters? ")" block ;
+parameters     ::= IDENTIFIER ( "," IDENTIFIER )* ;
+
+varDecl        ::= "var" IDENTIFIER ( "=" expression )? ";" ;
+
+(* Statements *)
+statement      ::= exprStmt
+                 | forStmt
+                 | ifStmt
+                 | printStmt
+                 | returnStmt
+                 | whileStmt
+                 | breakStmt
+                 | continueStmt
+                 | block ;
+
+exprStmt       ::= expression ";" ;
+
+forStmt        ::= "for" "(" ( varDecl | exprStmt | ";" )
+                              expression? ";"
+                              expression? ")"
+                   statement ;
+
+ifStmt         ::= "if" "(" expression ")" statement
+                   ( "else" statement )? ;
+
+printStmt      ::= "print" expression ";" ;
+
+returnStmt     ::= "return" expression? ";" ;
+
+whileStmt      ::= "while" "(" expression ")" statement ;
+
+breakStmt      ::= "break" ";" ;
+
+continueStmt   ::= "continue" ";" ;
+
+block          ::= "{" declaration* "}" ;
+
+(* Expressions — ordered from lowest to highest precedence *)
+expression     ::= assignment ;
+
+assignment     ::= IDENTIFIER "=" assignment
+                 | logicOr ;
+
+logicOr        ::= logicAnd ( "or" logicAnd )* ;
+
+logicAnd       ::= equality ( "and" equality )* ;
+
+equality       ::= comparison ( ( "!=" | "==" ) comparison )* ;
+
+comparison     ::= term ( ( ">" | ">=" | "<" | "<=" ) term )* ;
+
+term           ::= factor ( ( "-" | "+" ) factor )* ;
+
+factor         ::= unary ( ( "/" | "*" ) unary )* ;
+
+unary          ::= ( "!" | "-" ) unary
+                 | call ;
+
+call           ::= primary ( "(" arguments? ")" )* ;
+
+arguments      ::= expression ( "," expression )* ;
+
+primary        ::= "true"
+                 | "false"
+                 | "nil"
+                 | NUMBER
+                 | STRING
+                 | IDENTIFIER
+                 | "(" expression ")" ;
+```
+
+---
+
+## Operator Precedence
+
+The table below lists operator groups from **lowest** to **highest** precedence.
+Operators within the same group are left-associative unless noted otherwise.
+
+| Precedence | Operators | Associativity |
+|---|---|---|
+| 1 (lowest) | `=` (assignment) | Right |
+| 2 | `or` | Left |
+| 3 | `and` | Left |
+| 4 | `==` `!=` | Left |
+| 5 | `<` `<=` `>` `>=` | Left |
+| 6 | `+` `-` | Left |
+| 7 | `*` `/` | Left |
+| 8 | `!` `-` (unary) | Right (prefix) |
+| 9 (highest) | `()` (function call) | Left |
+
+---
+
+## Notes on Specific Constructs
+
+### `for` loop
+
+The three clauses of a `for` statement are each optional:
+
+- **Initializer**: either a `var` declaration (scoped to the loop), an
+  expression statement, or omitted (bare `;`).
+- **Condition**: an expression evaluated before each iteration; omitted means
+  always-truthy.
+- **Increment**: an expression evaluated after each iteration body; omitted
+  means nothing.
+
+### `if`/`else` dangling
+
+The `else` clause binds to the nearest preceding `if`. To associate an `else`
+with an outer `if`, enclose the inner `if` in a block.
+
+### Assignment
+
+Assignment is an expression, not a statement. The left-hand side must be a
+bare `IDENTIFIER`; complex left-hand-side expressions (e.g., property access)
+are not currently supported. The value of an assignment expression is the
+assigned value.
+
+### Function call arguments
+
+A call may pass up to 255 arguments. The maximum number of parameters a
+function may declare is also 255.

--- a/spec/03-types.md
+++ b/spec/03-types.md
@@ -8,7 +8,7 @@ types over its lifetime.
 
 ## Runtime Types
 
-There are five runtime types:
+There are eight runtime types:
 
 ### Nil
 
@@ -44,6 +44,27 @@ A function carries a **closure environment** — a snapshot of the lexical scope
 in which it was defined. Closures allow a function to access variables from
 enclosing scopes even after those scopes have exited.
 
+### Class
+
+A class value produced by a `class` declaration. When called as a function, it
+creates a new Instance of that class. Classes are first-class: they can be
+stored in variables, passed as arguments, and returned from functions.
+
+### Instance
+
+A runtime object created by calling a Class. Each instance has its own mutable
+field table. Fields spring into existence on first assignment; there is no
+pre-declared field list. An instance's class determines which methods are
+available on it.
+
+### BoundMethod
+
+A method that has been looked up on an instance. When `obj.method` is evaluated
+without an immediately following `(`, the result is a BoundMethod capturing
+both the method closure and `obj` as the receiver. Calling a BoundMethod is
+equivalent to calling the underlying function with `this` bound to the captured
+receiver.
+
 ---
 
 ## Truthiness
@@ -75,6 +96,8 @@ The `==` and `!=` operators compare two values.
   - Strings are equal when they contain the same sequence of characters
   - Functions are equal only when they are the same function object (identity
     equality)
+  - Classes, Instances, and BoundMethods use identity equality: two values are
+    equal only if they are the exact same object
 
 Equality never produces a runtime error regardless of the types being compared.
 
@@ -101,4 +124,7 @@ Every value has a canonical string form, produced by `print` and by the
 | Number (integer-valued) | Digits, no decimal point — `42`, `-3`, `0` |
 | Number (fractional) | Shortest decimal representation — `3.14`, `1.5` |
 | String | The string content itself (no surrounding quotes) |
-| Function | `<fn name>` where *name* is the declared function name |
+| Function / BoundMethod | `<fn name>` where *name* is the declared function name |
+| Native function | `<native fn>` |
+| Class | The class name (e.g. `Dog`) |
+| Instance | `ClassName instance` (e.g. `Dog instance`) |

--- a/spec/03-types.md
+++ b/spec/03-types.md
@@ -1,0 +1,104 @@
+# Lox++ Type System
+
+Lox++ is dynamically typed: every value carries its own type at runtime.
+Variables have no declared type; the same variable may hold values of different
+types over its lifetime.
+
+---
+
+## Runtime Types
+
+There are five runtime types:
+
+### Nil
+
+The type of the single value `nil`. Used to represent the absence of a
+meaningful value. Uninitialized variables hold `nil`.
+
+### Boolean
+
+One of exactly two values: `true` or `false`.
+
+### Number
+
+A 64-bit IEEE 754 double-precision floating-point value. There is no separate
+integer type; `1` and `1.0` are the same value.
+
+Special IEEE 754 values (positive/negative infinity, NaN) are not directly
+expressible as literals but may arise from certain arithmetic operations. Their
+behavior follows IEEE 754.
+
+### String
+
+An immutable sequence of bytes (interpreted as UTF-8). Two strings with
+identical content are equal regardless of how or where they were created.
+
+### Function
+
+A callable value that, when invoked with the correct number of arguments,
+evaluates its body and produces a return value. Functions are first-class: they
+can be stored in variables, passed as arguments, and returned from other
+functions.
+
+A function carries a **closure environment** — a snapshot of the lexical scope
+in which it was defined. Closures allow a function to access variables from
+enclosing scopes even after those scopes have exited.
+
+---
+
+## Truthiness
+
+Every value is either **truthy** or **falsy**. This determines behavior in
+conditions (`if`, `while`, `for`) and short-circuit operators (`and`, `or`).
+
+| Value | Truthiness |
+|---|---|
+| `false` | Falsy |
+| `nil` | Falsy |
+| Everything else | Truthy |
+
+Note: `0`, `""` (empty string), and functions are all **truthy**.
+
+---
+
+## Equality
+
+The `==` and `!=` operators compare two values.
+
+- Values of **different types** are **never equal**: `nil == false` → `false`,
+  `0 == "0"` → `false`.
+- Values of the **same type** are compared by **value**:
+  - `nil == nil` → `true`
+  - Booleans are equal when both are `true` or both are `false`
+  - Numbers are equal when they have the same numeric value (IEEE 754 equality;
+    note that `NaN != NaN` follows the standard)
+  - Strings are equal when they contain the same sequence of characters
+  - Functions are equal only when they are the same function object (identity
+    equality)
+
+Equality never produces a runtime error regardless of the types being compared.
+
+---
+
+## Type Coercion
+
+Lox++ performs **no implicit type conversions**. Passing a String where a
+Number is required (e.g., in arithmetic) is a runtime error. Use the `str()`
+built-in to convert explicitly.
+
+---
+
+## Canonical String Representation
+
+Every value has a canonical string form, produced by `print` and by the
+`str()` built-in:
+
+| Type / Value | String form |
+|---|---|
+| `nil` | `nil` |
+| `true` | `true` |
+| `false` | `false` |
+| Number (integer-valued) | Digits, no decimal point — `42`, `-3`, `0` |
+| Number (fractional) | Shortest decimal representation — `3.14`, `1.5` |
+| String | The string content itself (no surrounding quotes) |
+| Function | `<fn name>` where *name* is the declared function name |

--- a/spec/04-semantics.md
+++ b/spec/04-semantics.md
@@ -1,0 +1,328 @@
+# Lox++ Runtime Semantics
+
+## Evaluation Model
+
+**Expressions** are evaluated to produce a value.  
+**Statements** are executed for their effect; they do not produce a value.
+
+Evaluation proceeds left-to-right, depth-first, unless a specific rule states
+otherwise.
+
+---
+
+## Scoping
+
+Lox++ uses **lexical (static) scoping**.
+
+- The **global scope** spans the entire program.
+- A **local scope** is introduced by any `{ }` block (including function
+  bodies).
+- Scopes may nest arbitrarily. An inner scope may **shadow** a name from an
+  outer scope by declaring a new variable with the same name; the outer
+  variable is unaffected and becomes accessible again when the inner scope
+  exits.
+- Variables are resolved to the scope in which they were declared at the point
+  where the reference appears in source, not the scope active at the time of
+  execution.
+
+---
+
+## Variables
+
+### Declaration
+
+```
+var x;          // x is initialized to nil
+var y = expr;   // y is initialized to the value of expr
+```
+
+- A variable's declared scope is determined by where the `var` statement
+  appears.
+- Declaring a variable in the global scope makes it a global; inside a block
+  makes it a local.
+- Declaring a name that is already declared in the **same** scope is a
+  **static error**.
+- A variable may not appear in its own initializer expression — that is a
+  **static error**.
+
+### Reading
+
+Reading a global variable that has never been declared is a **runtime error**.
+
+Reading a local variable always succeeds (the declaration must have been
+reached or the program would have been rejected at the declaration site with
+a static error).
+
+### Assignment
+
+```
+x = expr
+```
+
+Evaluates `expr` and stores the result in the variable named `x`. The
+expression value is the assigned value. If `x` is not declared in any
+reachable scope this is a **runtime error**.
+
+---
+
+## Expressions
+
+### Literal Expressions
+
+`true`, `false`, `nil`, NUMBER, STRING each evaluate to the corresponding
+value.
+
+### Identifier
+
+Evaluating an identifier looks up the variable's current value in the scope
+chain.
+
+### Grouping
+
+`( expr )` evaluates `expr` and returns its value; parentheses only affect
+parsing precedence.
+
+### Arithmetic
+
+| Expression | Requirement | Result |
+|---|---|---|
+| `a + b` | Both Numbers, **or** both Strings | Sum (Number) or concatenated string |
+| `a - b` | Both Numbers | Difference |
+| `a * b` | Both Numbers | Product |
+| `a / b` | Both Numbers | Quotient |
+| `-a` | Number | Negation |
+
+Any violation of the type requirement is a **runtime error**.
+
+String concatenation (`+`) creates a new string whose content is the
+characters of the left operand followed by the characters of the right
+operand.
+
+Division follows IEEE 754; dividing by zero produces `Infinity` or
+`-Infinity` (not an error).
+
+### Comparison
+
+| Expression | Requirement | Result |
+|---|---|---|
+| `a < b` | Both Numbers | Boolean |
+| `a <= b` | Both Numbers | Boolean |
+| `a > b` | Both Numbers | Boolean |
+| `a >= b` | Both Numbers | Boolean |
+
+Any violation is a **runtime error**.
+
+### Equality
+
+`a == b` and `a != b` are defined for all type combinations and never produce
+a runtime error. See [03-types.md § Equality](03-types.md#equality).
+
+### Logical Operators (Short-Circuit)
+
+`and` and `or` do **not** necessarily return a Boolean; they return one of
+their operands.
+
+- `a and b` — evaluates `a`. If `a` is falsy, returns `a` without evaluating
+  `b`. Otherwise evaluates and returns `b`.
+- `a or b` — evaluates `a`. If `a` is truthy, returns `a` without evaluating
+  `b`. Otherwise evaluates and returns `b`.
+
+### Logical Negation
+
+`!a` — evaluates `a` and returns `false` if `a` is truthy, `true` if `a` is
+falsy. Always returns a Boolean.
+
+### Function Call
+
+```
+callee(arg1, arg2, ...)
+```
+
+1. Evaluate `callee`.
+2. Evaluate arguments left-to-right.
+3. If `callee` is not a Function, this is a **runtime error**.
+4. If the number of arguments does not match the function's arity, this is a
+   **runtime error**.
+5. A new local scope is created; each parameter is bound to the corresponding
+   argument.
+6. The function body executes.
+7. The call expression evaluates to the function's return value (or `nil` if
+   none).
+
+Functions may be called recursively. The depth limit is implementation-defined;
+exceeding it is a **runtime error**.
+
+---
+
+## Statements
+
+### Expression Statement
+
+```
+expr ;
+```
+
+Evaluates `expr` and discards the result.
+
+### Print Statement
+
+```
+print expr ;
+```
+
+Evaluates `expr` and writes its canonical string representation to standard
+output, followed by a newline character. `print` is a statement, not a
+function.
+
+### Variable Declaration
+
+See [Variables](#variables) above.
+
+### Block
+
+```
+{ declaration* }
+```
+
+Introduces a new local scope. Declarations and statements inside execute in
+order. Variables declared inside the block are destroyed when the block exits.
+
+### `if` Statement
+
+```
+if ( condition ) thenBranch
+if ( condition ) thenBranch else elseBranch
+```
+
+Evaluates `condition`. If truthy, executes `thenBranch`. If falsy and an
+`else` branch is present, executes `elseBranch`. Exactly one branch executes
+(or neither, if there is no `else` and the condition is falsy).
+
+### `while` Statement
+
+```
+while ( condition ) body
+```
+
+1. Evaluate `condition`.
+2. If falsy, exit the loop.
+3. Execute `body`.
+4. Repeat from step 1.
+
+### `for` Statement
+
+```
+for ( init ; condition ; increment ) body
+```
+
+Semantically equivalent to:
+
+```
+{
+    init ;
+    while ( condition ) {
+        body
+        increment ;
+    }
+}
+```
+
+Where:
+- `init` is a `var` declaration or expression statement, or omitted (bare
+  `;`). A `var` declaration here is scoped to the loop, not the enclosing
+  block.
+- `condition` is an expression evaluated before each iteration; if omitted it
+  is treated as `true`.
+- `increment` is an expression evaluated after each iteration body; if omitted
+  it is skipped.
+
+### `break` Statement
+
+```
+break ;
+```
+
+Immediately exits the innermost enclosing `while` or `for` loop. Any local
+variables declared inside the loop since its opening are destroyed. Executing
+`break` outside a loop is a **static error**.
+
+### `continue` Statement
+
+```
+continue ;
+```
+
+Skips the remainder of the current loop body and jumps to the next iteration:
+- In a `while` loop: jumps to re-evaluating the condition.
+- In a `for` loop: jumps to evaluating the increment expression, then the
+  condition.
+
+Any local variables declared inside the loop body since the top of the current
+iteration are destroyed. Executing `continue` outside a loop is a **static
+error**.
+
+### Function Declaration
+
+```
+fun name ( params ) { body }
+```
+
+Binds the name to a new Function value in the current scope. The function
+captures its lexical environment at the point of declaration (closure
+semantics). A function declared at the top level is a global; one declared
+inside a block is a local.
+
+### `return` Statement
+
+```
+return ;          // returns nil
+return expr ;     // returns the value of expr
+```
+
+Exits the current function immediately, yielding the given value (or `nil`).
+A `return` at the top level (outside any function body) is a **static error**.
+
+---
+
+## Closures
+
+When a function is created, it **closes over** variables from its enclosing
+lexical scopes. Accessing a closed-over variable from inside the function
+reads and writes the same storage as the outer scope, not a copy. If the outer
+scope exits while the closure is still reachable, the closed-over variables
+remain alive as long as the closure is reachable.
+
+```lox
+fun makeCounter() {
+    var count = 0;
+    fun increment() {
+        count = count + 1;
+        return count;
+    }
+    return increment;
+}
+
+var c = makeCounter();
+print c(); // 1
+print c(); // 2
+```
+
+Multiple closures created within the same scope share the same closed-over
+variable; mutating it through one closure is visible through all others.
+
+---
+
+## Runtime Errors
+
+A runtime error halts execution immediately and reports an error message.
+Common causes:
+
+| Cause | Example |
+|---|---|
+| Arithmetic on non-Numbers | `"a" - 1` |
+| Comparison on non-Numbers | `"a" < 1` |
+| `+` on incompatible types | `1 + "a"` |
+| Call of a non-Function | `42()` |
+| Wrong argument count | `fun f(a) {} f(1, 2)` |
+| Undefined global variable | `print undeclared;` |
+| Call stack overflow | Unbounded recursion |

--- a/spec/04-semantics.md
+++ b/spec/04-semantics.md
@@ -132,6 +132,79 @@ their operands.
 `!a` — evaluates `a` and returns `false` if `a` is truthy, `true` if `a` is
 falsy. Always returns a Boolean.
 
+### Property Get
+
+```
+obj.name
+```
+
+1. Evaluate `obj`.
+2. If `obj` is not an Instance, this is a **runtime error** ("Only instances have properties.").
+3. If the instance's field table contains `name`, return that field value. Fields shadow methods.
+4. Otherwise, look up `name` in the instance's class method table. If found, return a BoundMethod
+   wrapping the closure and `obj` as receiver.
+5. If neither step 3 nor 4 found `name`, this is a **runtime error** ("Undefined property 'name'.").
+
+### Property Set
+
+```
+obj.name = expr
+```
+
+1. Evaluate `obj`.
+2. If `obj` is not an Instance, this is a **runtime error** ("Only instances have fields.").
+3. Evaluate `expr`.
+4. Store the result in the instance's field table under `name` (creating the field if it does not
+   exist, overwriting if it does).
+5. The expression value is the assigned value.
+
+### Method Invocation
+
+```
+obj.method(arg1, arg2, ...)
+```
+
+Semantically equivalent to looking up `obj.method` and calling the result, but the implementation
+fuses both steps into a single `INVOKE` super-instruction. Fields take priority over methods: if
+the instance's field table contains `method`, that value is called (and must be callable). If the
+field value is not callable, that is a **runtime error**.
+
+### `this` Expression
+
+`this` evaluates to the instance on which the enclosing method was invoked. It is only valid inside
+a method body. Using `this` outside any class method is a **static error**.
+
+### `super` Expression
+
+```
+super.method
+super.method(arg1, arg2, ...)
+```
+
+`super.method` looks up `method` starting from the **superclass**, bypassing any override defined
+on the current class. It returns a BoundMethod with `this` bound to the current receiver. The
+`super.method(args)` form fuses this with a call via the `SUPER_INVOKE` super-instruction.
+
+`super` is lexically captured: it closes over the superclass value at class-definition time, not
+at call time.
+
+Using `super` outside a method body, or inside a method of a class with no declared superclass, is
+a **static error**.
+
+### Instance Creation
+
+```
+ClassName(arg1, arg2, ...)
+```
+
+Calling a Class value creates a new Instance:
+
+1. A fresh Instance of the class is allocated with an empty field table.
+2. If the class (or any inherited class) defines an `init` method, it is invoked with `this` bound
+   to the new instance and the supplied arguments. Arity rules apply to `init`.
+3. If no `init` method exists and arguments were supplied, this is a **runtime error**.
+4. The call expression evaluates to the new Instance; the return value of `init` is ignored.
+
 ### Function Call
 
 ```
@@ -140,7 +213,7 @@ callee(arg1, arg2, ...)
 
 1. Evaluate `callee`.
 2. Evaluate arguments left-to-right.
-3. If `callee` is not a Function, this is a **runtime error**.
+3. If `callee` is not a Function, Class, or BoundMethod, this is a **runtime error**.
 4. If the number of arguments does not match the function's arity, this is a
    **runtime error**.
 5. A new local scope is created; each parameter is bound to the corresponding
@@ -261,6 +334,34 @@ Any local variables declared inside the loop body since the top of the current
 iteration are destroyed. Executing `continue` outside a loop is a **static
 error**.
 
+### Class Declaration
+
+```
+class Name { method* }
+class Name < SuperName { method* }
+```
+
+1. If `< SuperName` is present, evaluates `SuperName`. If it is not a Class, this is a
+   **runtime error** ("Superclass must be a class."). A class cannot inherit from itself — that is
+   a **static error**.
+2. A new Class value is created with the given `Name`.
+3. If a superclass is present, its method table is **copied into the new class at definition
+   time** — not at call time. Later changes to the superclass do not affect the subclass.
+4. Each `method` body is compiled and stored in the class's method table (overwriting any inherited
+   method with the same name).
+5. The class value is bound to `Name` in the current scope (global if at top level, local
+   otherwise).
+
+### `init` — Initializer Method
+
+`init` is a specially named method that, if defined, is called automatically whenever an Instance
+of the class is created (see "Instance Creation" above).
+
+- Inside `init`, a bare `return ;` exits early; `this` is still returned as the call result.
+- `return expr ;` with a non-`nil` expression inside `init` is a **static error** ("Can't return a
+  value from an initializer.").
+- `init` implicitly returns `this`.
+
 ### Function Declaration
 
 ```
@@ -322,7 +423,7 @@ Common causes:
 | Arithmetic on non-Numbers | `"a" - 1` |
 | Comparison on non-Numbers | `"a" < 1` |
 | `+` on incompatible types | `1 + "a"` |
-| Call of a non-Function | `42()` |
+| Call of a non-callable value | `42()` |
 | Wrong argument count | `fun f(a) {} f(1, 2)` |
 | Undefined global variable | `print undeclared;` |
 | Call stack overflow | Unbounded recursion |

--- a/spec/05-stdlib.md
+++ b/spec/05-stdlib.md
@@ -1,0 +1,67 @@
+# Lox++ Standard Library
+
+The following functions are available in the global scope at the start of
+every program. They behave like user-defined functions in all respects
+(first-class values, strict arity enforcement) except that their bodies are
+provided by the host environment.
+
+---
+
+## `clock() → Number`
+
+Returns the elapsed processor time in seconds as a Number.
+
+The reference epoch (the point in time corresponding to `0`) is unspecified
+and implementation-defined. The intended use is measuring elapsed time between
+two calls:
+
+```lox
+var start = clock();
+// ... work ...
+var elapsed = clock() - start;
+print str(elapsed) + " seconds";
+```
+
+**Arity:** 0  
+**Returns:** Number
+
+---
+
+## `input() → String | Nil`
+
+Reads one line of text from standard input and returns it as a String, with
+the trailing newline character removed.
+
+Returns `nil` if the end of input has been reached (EOF).
+
+```lox
+var line = input();
+if (line == nil) {
+    print "No more input.";
+} else {
+    print "You typed: " + line;
+}
+```
+
+**Arity:** 0  
+**Returns:** String on success, Nil on EOF
+
+---
+
+## `str(value) → String`
+
+Converts `value` to its canonical string representation (the same text that
+`print` would output) and returns it as a String value.
+
+```lox
+print str(42);      // 42
+print str(true);    // true
+print str(nil);     // nil
+print str(3.14);    // 3.14
+```
+
+This is the only built-in mechanism for converting a non-String value to a
+String so that it can be concatenated with `+`.
+
+**Arity:** 1  
+**Returns:** String

--- a/spec/05-stdlib.md
+++ b/spec/05-stdlib.md
@@ -58,7 +58,17 @@ print str(42);      // 42
 print str(true);    // true
 print str(nil);     // nil
 print str(3.14);    // 3.14
+
+class Dog {}
+print str(Dog);         // Dog
+var d = Dog();
+print str(d);           // Dog instance
 ```
+
+For Class values, `str()` returns the class name. For Instance values, it
+returns `"ClassName instance"`. For BoundMethod and native function values, it
+returns `"<fn name>"` or `"<native fn>"` respectively, matching the canonical
+forms documented in §03-types.
 
 This is the only built-in mechanism for converting a non-String value to a
 String so that it can be concatenated with `+`.

--- a/spec/README.md
+++ b/spec/README.md
@@ -75,7 +75,7 @@ variant) and adds the following:
 | `clock()` built-in | Added in Lox++ |
 | `input()` built-in | Added in Lox++ |
 | `str()` built-in | Added in Lox++ |
-| Classes (`class`, `super`, `this`) | Reserved; not yet defined |
+| Classes (`class`, `super`, `this`) | Added in Lox++ |
 
 ---
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,90 @@
+# Lox++ Language Specification
+
+## What Is Lox++?
+
+Lox++ is a dynamically typed, expression-oriented scripting language descended
+from the Lox language designed by Robert Nystrom in *Crafting Interpreters*. It
+preserves the simplicity and clarity of the original Lox while introducing
+pragmatic extensions for real-world use.
+
+This specification defines the Lox++ language independently of any particular
+implementation. A conforming implementation may use any execution strategy —
+tree-walking interpretation, bytecode compilation, native compilation, or
+otherwise — provided that the observable behavior matches what is described
+here.
+
+---
+
+## Design Goals
+
+- **Simple**: a small, learnable surface area; no hidden complexity
+- **Dynamically typed**: types are associated with values, not variable
+  declarations
+- **Expression-oriented**: most constructs produce a value
+- **First-class functions**: functions are values; closures are the fundamental
+  unit of abstraction
+- **Fail loudly**: type errors and undefined behavior are detected at runtime
+  and reported as errors, never silently ignored
+
+---
+
+## Notation
+
+Grammar throughout this specification is written in **EBNF**:
+
+| Notation | Meaning |
+|---|---|
+| `::=` | Defines a non-terminal |
+| `"terminal"` | Literal token |
+| `UPPER_CASE` | Token category (e.g. `IDENTIFIER`, `NUMBER`) |
+| `rule*` | Zero or more repetitions |
+| `rule+` | One or more repetitions |
+| `rule?` | Optional (zero or one) |
+| `a \| b` | Alternation: a or b |
+| `( a b )` | Grouping |
+| `;` | End of a production |
+
+---
+
+## Error Taxonomy
+
+**Static error** — detected before any code executes (e.g. during parsing or
+variable resolution). A conforming implementation must report a static error
+and must not execute the program that contains one.
+
+Examples: `break` outside a loop, `return` at the top level, self-referential
+variable initializer, duplicate name in the same scope.
+
+**Runtime error** — detected during execution. A conforming implementation
+must halt execution and report the error.
+
+Examples: arithmetic on a non-Number, calling a non-function, wrong number of
+arguments, reading an undeclared global variable.
+
+---
+
+## Relationship to Book Lox
+
+Lox++ begins from the Lox specification in *Crafting Interpreters* (clox
+variant) and adds the following:
+
+| Feature | Status |
+|---|---|
+| `break` statement | Added in Lox++ |
+| `continue` statement | Added in Lox++ |
+| `clock()` built-in | Added in Lox++ |
+| `input()` built-in | Added in Lox++ |
+| `str()` built-in | Added in Lox++ |
+| Classes (`class`, `super`, `this`) | Reserved; not yet defined |
+
+---
+
+## Files in This Specification
+
+| File | Contents |
+|---|---|
+| [`01-lexical.md`](01-lexical.md) | Source encoding, whitespace, comments, all token forms |
+| [`02-syntax.md`](02-syntax.md) | Complete EBNF grammar and operator precedence table |
+| [`03-types.md`](03-types.md) | Runtime types, truthiness, equality, canonical string form |
+| [`04-semantics.md`](04-semantics.md) | Evaluation rules for every expression and statement |
+| [`05-stdlib.md`](05-stdlib.md) | Built-in functions available at program start |


### PR DESCRIPTION
## Summary

- Adds `spec/` directory with a six-file formal language specification for Lox++
- Covers lexical grammar, EBNF syntax, type system, runtime semantics, and standard library
- Implementation-agnostic: describes observable behavior only, no internal details
- Faithful to the current language as a baseline for future Lox++ extensions

## Files

| File | Contents |
|---|---|
| `spec/README.md` | Overview, design goals, notation guide, deviation table |
| `spec/01-lexical.md` | Source encoding, whitespace, comments, all token forms |
| `spec/02-syntax.md` | Complete EBNF grammar and operator precedence table |
| `spec/03-types.md` | Runtime types, truthiness, equality, canonical string forms |
| `spec/04-semantics.md` | Evaluation rules for every expression and statement |
| `spec/05-stdlib.md` | Built-in functions: `clock`, `input`, `str` |

## Test plan

- [ ] Review spec files for accuracy against existing behavior
- [ ] Cross-check EBNF grammar against test suite constructs
- [ ] Verify keyword list, truthiness rules, and stdlib signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)