### PR TITLE
feat: add classes and instances

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -39,6 +39,9 @@ enum class Op : Byte {
     GET_UPVALUE,
     SET_UPVALUE,
     CLOSE_UPVALUE,
+    CLASS,
+    GET_PROPERTY,
+    SET_PROPERTY,
 };
 
 inline Op toOpcode(Byte byte) { return static_cast<Op>(byte); }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -179,7 +179,9 @@ void Compiler::call() {
 }
 
 void Compiler::declaration() {
-    if (m_parser->match(TokenType::FUN)) {
+    if (m_parser->match(TokenType::CLASS)) {
+        classDeclaration();
+    } else if (m_parser->match(TokenType::FUN)) {
         funDeclaration();
     } else if (m_parser->match(TokenType::VAR)) {
         varDeclaration();
@@ -477,6 +479,37 @@ void Compiler::funDeclaration() {
     }
     if (m_scopeDepth == 0) {
         emitBytes(Op::DEFINE_GLOBAL, nameConst);
+    }
+}
+
+void Compiler::classDeclaration() {
+    m_parser->consume(TokenType::IDENTIFIER, "Expect class name.");
+    Token className = m_parser->m_previous;
+    uint8_t nameConst = identifierConstant(className);
+
+    if (m_scopeDepth > 0)
+        declareVariable();
+
+    emitBytes(Op::CLASS, nameConst);
+
+    if (m_scopeDepth > 0)
+        markInitialized();
+    else
+        emitBytes(Op::DEFINE_GLOBAL, nameConst);
+
+    m_parser->consume(TokenType::LEFT_BRACE, "Expect '{' before class body.");
+    m_parser->consume(TokenType::RIGHT_BRACE, "Expect '}' after class body.");
+}
+
+void Compiler::dot() {
+    m_parser->consume(TokenType::IDENTIFIER, "Expect property name after '.'.");
+    uint8_t nameConst = identifierConstant(m_parser->m_previous);
+
+    if (m_parser->m_canAssign && m_parser->match(TokenType::EQUAL)) {
+        expression();
+        emitBytes(Op::SET_PROPERTY, nameConst);
+    } else {
+        emitBytes(Op::GET_PROPERTY, nameConst);
     }
 }
 

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -14,7 +14,7 @@ static constexpr int UINT8_COUNT = 256;
 
 ObjFunction* compile(const std::string& source, MemoryManager* mm);
 
-enum class FunctionType { SCRIPT, FUNCTION };
+enum class FunctionType { SCRIPT, FUNCTION, METHOD };
 
 struct Local {
     Token name;
@@ -67,10 +67,12 @@ class Compiler {
     void varDeclaration();
     void block();
     void funDeclaration();
+    void classDeclaration();
     void returnStatement();
 
     void and_();
     void or_();
+    void dot();
 
   private:
     void beginScope();

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -145,6 +145,12 @@ int disassembleInstruction(const Chunk& chunk, const MemoryManager& mm,
         return byteInstruction("SET_UPVALUE", chunk, offset, out, color);
     case Op::CLOSE_UPVALUE:
         return simpleInstruction("CLOSE_UPVALUE", offset, out, color);
+    case Op::CLASS:
+        return constantInstruction("CLASS", chunk, mm, offset, out, color);
+    case Op::GET_PROPERTY:
+        return constantInstruction("GET_PROPERTY", chunk, mm, offset, out, color);
+    case Op::SET_PROPERTY:
+        return constantInstruction("SET_PROPERTY", chunk, mm, offset, out, color);
     default:
         out << cc(color, kRed) << cc(color, kBold) << "UNKNOWN("
             << static_cast<unsigned>(chunk.at(offset)) << ")"

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -148,9 +148,11 @@ int disassembleInstruction(const Chunk& chunk, const MemoryManager& mm,
     case Op::CLASS:
         return constantInstruction("CLASS", chunk, mm, offset, out, color);
     case Op::GET_PROPERTY:
-        return constantInstruction("GET_PROPERTY", chunk, mm, offset, out, color);
+        return constantInstruction("GET_PROPERTY", chunk, mm, offset, out,
+                                   color);
     case Op::SET_PROPERTY:
-        return constantInstruction("SET_PROPERTY", chunk, mm, offset, out, color);
+        return constantInstruction("SET_PROPERTY", chunk, mm, offset, out,
+                                   color);
     default:
         out << cc(color, kRed) << cc(color, kBold) << "UNKNOWN("
             << static_cast<unsigned>(chunk.at(offset)) << ")"

--- a/src/function.h
+++ b/src/function.h
@@ -80,7 +80,9 @@ struct ObjInstance : public Obj {
 };
 
 inline bool isObjInstance(Obj* o) { return isObjType(o, ObjType::INSTANCE); }
-inline ObjInstance* asObjInstance(Obj* o) { return static_cast<ObjInstance*>(o); }
+inline ObjInstance* asObjInstance(Obj* o) {
+    return static_cast<ObjInstance*>(o);
+}
 inline bool isInstance(const Value& v) {
     return is<Obj*>(v) && as<Obj*>(v)->type == ObjType::INSTANCE;
 }

--- a/src/function.h
+++ b/src/function.h
@@ -2,6 +2,7 @@
 
 #include "chunk.h"
 #include "object.h"
+#include "table.h"
 #include "value.h"
 
 #include <vector>
@@ -54,4 +55,32 @@ inline ObjClosure* asObjClosure(const Value& v) {
 }
 inline bool isClosure(const Value& v) {
     return is<Obj*>(v) && as<Obj*>(v)->type == ObjType::CLOSURE;
+}
+
+struct ObjClass : public Obj {
+    ObjString* name;
+    Table methods; // ObjString* → ObjClosure* (populated in future chapters)
+
+    ObjClass(ObjString* n, VmAllocator<Entry> alloc)
+        : Obj(ObjType::CLASS), name(n), methods(alloc) {}
+};
+
+inline bool isObjClass(Obj* o) { return isObjType(o, ObjType::CLASS); }
+inline ObjClass* asObjClass(Obj* o) { return static_cast<ObjClass*>(o); }
+inline bool isClass(const Value& v) {
+    return is<Obj*>(v) && as<Obj*>(v)->type == ObjType::CLASS;
+}
+
+struct ObjInstance : public Obj {
+    ObjClass* klass;
+    Table fields; // ObjString* → Value (arbitrary runtime fields)
+
+    ObjInstance(ObjClass* k, VmAllocator<Entry> alloc)
+        : Obj(ObjType::INSTANCE), klass(k), fields(alloc) {}
+};
+
+inline bool isObjInstance(Obj* o) { return isObjType(o, ObjType::INSTANCE); }
+inline ObjInstance* asObjInstance(Obj* o) { return static_cast<ObjInstance*>(o); }
+inline bool isInstance(const Value& v) {
+    return is<Obj*>(v) && as<Obj*>(v)->type == ObjType::INSTANCE;
 }

--- a/src/memory_manager.cpp
+++ b/src/memory_manager.cpp
@@ -2,6 +2,7 @@
 #include "compiler.h"
 #include "function.h"
 #include "native.h"
+#include "table.h"
 #include "value.h"
 
 #include <cstdio>
@@ -19,6 +20,10 @@ static const char* objTypeName(ObjType type) {
         return "upvalue";
     case ObjType::CLOSURE:
         return "closure";
+    case ObjType::CLASS:
+        return "class";
+    case ObjType::INSTANCE:
+        return "instance";
     }
     return "?";
 }
@@ -126,6 +131,24 @@ void MemoryManager::traceObject(Obj* obj) {
         markObject(cl->function);
         for (auto* uv : cl->upvalues)
             markObject(uv);
+        break;
+    }
+    case ObjType::CLASS: {
+        auto* klass = static_cast<ObjClass*>(obj);
+        markObject(klass->name);
+        klass->methods.forEach([this](ObjString* k, Value v) {
+            markObject(k);
+            markValue(v);
+        });
+        break;
+    }
+    case ObjType::INSTANCE: {
+        auto* inst = static_cast<ObjInstance*>(obj);
+        markObject(inst->klass);
+        inst->fields.forEach([this](ObjString* k, Value v) {
+            markObject(k);
+            markValue(v);
+        });
         break;
     }
     }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -33,7 +33,8 @@ std::string stringifyObj(Obj* obj) {
         return "<upvalue>";
     case ObjType::CLASS: {
         auto* klass = static_cast<ObjClass*>(obj);
-        return std::string(klass->name->chars.data(), klass->name->chars.size());
+        return std::string(klass->name->chars.data(),
+                           klass->name->chars.size());
     }
     case ObjType::INSTANCE: {
         auto* inst = static_cast<ObjInstance*>(obj);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1,5 +1,6 @@
 #include "object.h"
 #include "function.h"
+#include "table.h"
 
 #include <cstdio>
 #include <string>
@@ -30,6 +31,16 @@ std::string stringifyObj(Obj* obj) {
     }
     case ObjType::UPVALUE:
         return "<upvalue>";
+    case ObjType::CLASS: {
+        auto* klass = static_cast<ObjClass*>(obj);
+        return std::string(klass->name->chars.data(), klass->name->chars.size());
+    }
+    case ObjType::INSTANCE: {
+        auto* inst = static_cast<ObjInstance*>(obj);
+        return std::string(inst->klass->name->chars.data(),
+                           inst->klass->name->chars.size()) +
+               " instance";
+    }
     }
     return "<obj>";
 }

--- a/src/object.h
+++ b/src/object.h
@@ -6,7 +6,15 @@
 #include <string>
 #include <string_view>
 
-enum class ObjType : uint8_t { STRING, FUNCTION, NATIVE, UPVALUE, CLOSURE, CLASS, INSTANCE };
+enum class ObjType : uint8_t {
+    STRING,
+    FUNCTION,
+    NATIVE,
+    UPVALUE,
+    CLOSURE,
+    CLASS,
+    INSTANCE
+};
 
 inline uint32_t hashString(std::string_view s) {
     uint32_t hash = 2166136261U;

--- a/src/object.h
+++ b/src/object.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <string_view>
 
-enum class ObjType : uint8_t { STRING, FUNCTION, NATIVE, UPVALUE, CLOSURE };
+enum class ObjType : uint8_t { STRING, FUNCTION, NATIVE, UPVALUE, CLOSURE, CLASS, INSTANCE };
 
 inline uint32_t hashString(std::string_view s) {
     uint32_t hash = 2166136261U;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -13,7 +13,7 @@ static const ParseRule rules[] = {
     RULE(LEFT_BRACE,     nullptr,             nullptr,           NONE),
     RULE(RIGHT_BRACE,    nullptr,             nullptr,           NONE),
     RULE(COMMA,          nullptr,             nullptr,           NONE),
-    RULE(DOT,            nullptr,             nullptr,           NONE),
+    RULE(DOT,            nullptr,             &Compiler::dot,    CALL),
     RULE(MINUS,          &Compiler::unary,    &Compiler::binary, TERM),
     RULE(PLUS,           nullptr,             &Compiler::binary, TERM),
     RULE(SEMICOLON,      nullptr,             nullptr,           NONE),

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -313,8 +313,8 @@ InterpretResult VM::run() {
                 frame = &m_frames[m_frameCount - 1];
             } else if (isClass(callee)) {
                 ObjClass* klass = asObjClass(as<Obj*>(callee));
-                ObjInstance* instance = m_mm.create<ObjInstance>(
-                    klass, VmAllocator<Entry>{&m_mm});
+                ObjInstance* instance =
+                    m_mm.create<ObjInstance>(klass, VmAllocator<Entry>{&m_mm});
                 // Replace the class on the stack with the new instance.
                 stackTop[-argCount - 1] = Value{static_cast<Obj*>(instance)};
                 if (argCount != 0) {
@@ -329,7 +329,8 @@ InterpretResult VM::run() {
         }
         case Op::CLASS: {
             ObjString* name = asObjString(readConstant());
-            ObjClass* klass = m_mm.create<ObjClass>(name, VmAllocator<Entry>{&m_mm});
+            ObjClass* klass =
+                m_mm.create<ObjClass>(name, VmAllocator<Entry>{&m_mm});
             push(Value{static_cast<Obj*>(klass)});
             break;
         }

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -311,10 +311,55 @@ InterpretResult VM::run() {
                     return InterpretResult::RUNTIME_ERROR;
                 }
                 frame = &m_frames[m_frameCount - 1];
+            } else if (isClass(callee)) {
+                ObjClass* klass = asObjClass(as<Obj*>(callee));
+                ObjInstance* instance = m_mm.create<ObjInstance>(
+                    klass, VmAllocator<Entry>{&m_mm});
+                // Replace the class on the stack with the new instance.
+                stackTop[-argCount - 1] = Value{static_cast<Obj*>(instance)};
+                if (argCount != 0) {
+                    runtimeError("Expected 0 arguments but got %d.", argCount);
+                    return InterpretResult::RUNTIME_ERROR;
+                }
             } else {
                 runtimeError("Can only call functions and classes.");
                 return InterpretResult::RUNTIME_ERROR;
             }
+            break;
+        }
+        case Op::CLASS: {
+            ObjString* name = asObjString(readConstant());
+            ObjClass* klass = m_mm.create<ObjClass>(name, VmAllocator<Entry>{&m_mm});
+            push(Value{static_cast<Obj*>(klass)});
+            break;
+        }
+        case Op::GET_PROPERTY: {
+            if (!isInstance(peek(0))) {
+                runtimeError("Only instances have properties.");
+                return InterpretResult::RUNTIME_ERROR;
+            }
+            ObjInstance* instance = asObjInstance(as<Obj*>(peek(0)));
+            ObjString* name = asObjString(readConstant());
+            Value value;
+            if (instance->fields.get(name, value)) {
+                pop(); // instance
+                push(value);
+                break;
+            }
+            runtimeError("Undefined property '%s'.", name->chars.c_str());
+            return InterpretResult::RUNTIME_ERROR;
+        }
+        case Op::SET_PROPERTY: {
+            if (!isInstance(peek(1))) {
+                runtimeError("Only instances have fields.");
+                return InterpretResult::RUNTIME_ERROR;
+            }
+            ObjInstance* instance = asObjInstance(as<Obj*>(peek(1)));
+            ObjString* name = asObjString(readConstant());
+            instance->fields.set(name, peek(0));
+            Value val = pop(); // value
+            pop();             // instance
+            push(val);         // assignment is an expression
             break;
         }
         case Op::CLOSURE: {


### PR DESCRIPTION
## Summary

- Add `ObjClass` and `ObjInstance` heap objects (in `function.h` to avoid circular include with `table.h`)
- Add three new opcodes: `CLASS`, `GET_PROPERTY`, `SET_PROPERTY`
- Compiler: `classDeclaration()` emits `Op::CLASS` and binds the class as a global/local; `dot()` infix parselet handles `instance.field` reads and writes
- VM: `Op::CLASS` allocates an `ObjClass`; `Op::CALL` on a class creates an `ObjInstance`; `Op::GET/SET_PROPERTY` do hash-table lookups on instance fields
- GC: `traceObject` updated to mark class names, methods tables, instance class pointers, and field tables
- Disassembler updated for all three new opcodes

Implements chapter 27 of *Crafting Interpreters* (no `this`/`super`/`init` yet — those are ch28).

## Test plan

- [x] All 10 existing tests pass (`ctest`)
- [x] Manual smoke test: class declaration prints class name; `Foo()` creates an instance; `inst.x = v` / `inst.x` set and get fields correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)