### PR TITLE
fix: make rawAlloc trigger GC + add LOXPP_STRESS_GC mode (#33)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,11 @@ option(LOXPP_DEBUG_LOG_GC
 if(LOXPP_DEBUG_LOG_GC)
     target_compile_definitions(loxpp PRIVATE LOXPP_DEBUG_LOG_GC)
 endif()
+option(LOXPP_STRESS_GC
+    "Force garbage collection on every allocation (sets m_nextGC=0)" ${_debug_default})
+if(LOXPP_STRESS_GC)
+    target_compile_definitions(loxpp PRIVATE LOXPP_STRESS_GC)
+endif()
 
 # Readline support for the REPL.
 find_library(READLINE_LIB readline)

--- a/src/memory_manager.cpp
+++ b/src/memory_manager.cpp
@@ -28,6 +28,13 @@ MemoryManager::MemoryManager() : m_strings(VmAllocator<Entry>{this}) {}
 
 MemoryManager::~MemoryManager() { collectAll(); }
 
+void* MemoryManager::rawAlloc(std::size_t bytes) {
+    bytesAllocated += bytes;
+    if (bytesAllocated > m_nextGC)
+        collectGarbage();
+    return ::operator new(bytes);
+}
+
 void MemoryManager::release(Obj* obj, std::size_t size) {
     bytesAllocated -= size;
     delete obj;

--- a/src/memory_manager.h
+++ b/src/memory_manager.h
@@ -44,6 +44,8 @@ class MemoryManager : public VmAllocBase {
 
     void collectAll();
 
+    void* rawAlloc(std::size_t bytes) override;
+
     void setMarkRootsCallback(std::function<void()> cb);
     void setCurrentCompiler(Compiler* c);
     void markObject(Obj* obj);
@@ -64,6 +66,10 @@ class MemoryManager : public VmAllocBase {
     std::vector<Obj*> m_grayStack;
     std::function<void()> m_markRoots;
     Compiler* m_currentCompiler{nullptr};
+#ifdef LOXPP_STRESS_GC
+    std::size_t m_nextGC{0};
+#else
     std::size_t m_nextGC{1024 * 1024};
+#endif
     static constexpr int GC_HEAP_GROW_FACTOR = 2;
 };

--- a/src/vm_allocator.h
+++ b/src/vm_allocator.h
@@ -12,7 +12,7 @@
 //   memory_manager.h → object.h, table.h → vm_allocator.h
 struct VmAllocBase {
     std::size_t bytesAllocated{0};
-    void* rawAlloc(std::size_t bytes) {
+    virtual void* rawAlloc(std::size_t bytes) {
         bytesAllocated += bytes;
         return ::operator new(bytes);
     }
@@ -20,6 +20,7 @@ struct VmAllocBase {
         bytesAllocated -= bytes;
         ::operator delete(p);
     }
+    virtual ~VmAllocBase() = default;
 };
 
 template <typename T>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(test_local_variables test_local_variables.cpp test_harness.cpp ${
 add_executable(test_control_flow test_control_flow.cpp test_harness.cpp ${FULL_SRCS})
 add_executable(test_vm_runtime test_vm_runtime.cpp test_harness.cpp ${FULL_SRCS})
 add_executable(test_closures test_closures.cpp test_harness.cpp ${FULL_SRCS})
+add_executable(test_stress_gc test_stress_gc.cpp test_harness.cpp ${FULL_SRCS})
 
 target_include_directories(test_main PRIVATE ${PROJECT_SOURCE_DIR}/src)
 target_include_directories(test_scanner PRIVATE ${PROJECT_SOURCE_DIR}/src)
@@ -42,6 +43,9 @@ target_include_directories(test_local_variables PRIVATE ${PROJECT_SOURCE_DIR}/sr
 target_include_directories(test_control_flow PRIVATE ${PROJECT_SOURCE_DIR}/src)
 target_include_directories(test_vm_runtime PRIVATE ${PROJECT_SOURCE_DIR}/src)
 target_include_directories(test_closures PRIVATE ${PROJECT_SOURCE_DIR}/src)
+target_include_directories(test_stress_gc PRIVATE ${PROJECT_SOURCE_DIR}/src)
+
+target_compile_definitions(test_stress_gc PRIVATE LOXPP_STRESS_GC)
 
 target_link_libraries(test_scanner PRIVATE GTest::GTest GTest::Main)
 target_link_libraries(test_parser_vm PRIVATE GTest::GTest GTest::Main)
@@ -52,6 +56,7 @@ target_link_libraries(test_local_variables PRIVATE GTest::GTest GTest::Main)
 target_link_libraries(test_control_flow PRIVATE GTest::GTest GTest::Main)
 target_link_libraries(test_vm_runtime PRIVATE GTest::GTest GTest::Main)
 target_link_libraries(test_closures PRIVATE GTest::GTest GTest::Main)
+target_link_libraries(test_stress_gc PRIVATE GTest::GTest GTest::Main)
 
 add_test(NAME TestMain COMMAND test_main)
 add_test(NAME TestScanner COMMAND test_scanner)
@@ -63,3 +68,4 @@ add_test(NAME TestLocalVariables COMMAND test_local_variables)
 add_test(NAME TestControlFlow COMMAND test_control_flow)
 add_test(NAME TestVMRuntime COMMAND test_vm_runtime)
 add_test(NAME TestClosures COMMAND test_closures)
+add_test(NAME TestStressGC COMMAND test_stress_gc)

--- a/test/test_stress_gc.cpp
+++ b/test/test_stress_gc.cpp
@@ -1,0 +1,123 @@
+// test_stress_gc.cpp — GC correctness under maximum allocation pressure.
+//
+// This binary is always compiled with LOXPP_STRESS_GC, which sets m_nextGC=0
+// so every allocation (create<T> and rawAlloc) triggers a full collection.
+// The tests verify that ordinary programs produce correct results even when
+// every single allocation may free unreachable objects.
+
+#include "test_harness.h"
+#include <gtest/gtest.h>
+
+class StressGCTest : public ::testing::Test {};
+
+// ---------------------------------------------------------------------------
+// String allocation and interning
+// ---------------------------------------------------------------------------
+
+TEST_F(StressGCTest, StringConcatSurvivesGC) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run(R"(
+        var a = "hello";
+        var b = "world";
+        var c = a + " " + b;
+    )"),
+              InterpretResult::OK);
+    EXPECT_EQ(h.getGlobalStr("c"), "hello world");
+    EXPECT_EQ(h.stackDepth(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Global function declaration and call
+// ---------------------------------------------------------------------------
+
+TEST_F(StressGCTest, GlobalFunctionSurvivesGC) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run(R"(
+        fun add(a, b) { return a + b; }
+        var result = add(1, 2);
+    )"),
+              InterpretResult::OK);
+    auto v = h.getGlobal("result");
+    ASSERT_TRUE(v.has_value());
+    EXPECT_DOUBLE_EQ(std::get<Number>(*v), 3.0);
+    EXPECT_EQ(h.stackDepth(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Local function declaration (the GC-unsafe path fixed by #32 — kept for
+// documentation, not the focus of this PR, but stress mode surfaces it if
+// present).
+// ---------------------------------------------------------------------------
+
+TEST_F(StressGCTest, LocalFunctionSurvivesGC) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run(R"(
+        fun outer() {
+            fun inner(x) { return x * 2; }
+            return inner(21);
+        }
+        var result = outer();
+    )"),
+              InterpretResult::OK);
+    auto v = h.getGlobal("result");
+    ASSERT_TRUE(v.has_value());
+    EXPECT_DOUBLE_EQ(std::get<Number>(*v), 42.0);
+    EXPECT_EQ(h.stackDepth(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Closure capture and mutation
+// ---------------------------------------------------------------------------
+
+TEST_F(StressGCTest, ClosureCaptureSurvivesGC) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run(R"(
+        fun makeCounter() {
+            var count = 0;
+            fun increment() { count = count + 1; return count; }
+            return increment;
+        }
+        var counter = makeCounter();
+        counter();
+        var result = counter();
+    )"),
+              InterpretResult::OK);
+    auto v = h.getGlobal("result");
+    ASSERT_TRUE(v.has_value());
+    EXPECT_DOUBLE_EQ(std::get<Number>(*v), 2.0);
+    EXPECT_EQ(h.stackDepth(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Recursion (many stack frames + string/numeric allocations)
+// ---------------------------------------------------------------------------
+
+TEST_F(StressGCTest, RecursionSurvivesGC) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run(R"(
+        fun fib(n) {
+            if (n <= 1) return n;
+            return fib(n - 1) + fib(n - 2);
+        }
+        var result = fib(10);
+    )"),
+              InterpretResult::OK);
+    auto v = h.getGlobal("result");
+    ASSERT_TRUE(v.has_value());
+    EXPECT_DOUBLE_EQ(std::get<Number>(*v), 55.0);
+    EXPECT_EQ(h.stackDepth(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Native functions (defineNative allocates ObjNative then calls makeString)
+// ---------------------------------------------------------------------------
+
+TEST_F(StressGCTest, NativeFunctionSurvivesGC) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run(R"(
+        var s = str(42);
+    )"),
+              InterpretResult::OK);
+    EXPECT_EQ(h.getGlobalStr("s"), "42");
+    EXPECT_EQ(h.stackDepth(), 0);
+}


### PR DESCRIPTION
## Summary

- `VmAllocBase::rawAlloc` incremented `bytesAllocated` but never checked `m_nextGC`, so allocations through `VmAllocator<T>` (Table bucket resizes, `LoxString` char buffers, `VmVector`) were invisible to the GC trigger
- Fix: make `rawAlloc` virtual and override it in `MemoryManager` with the same threshold check that `create<T>()` already applies
- Add `LOXPP_STRESS_GC` cmake option (defaults ON for Debug builds) that sets `m_nextGC=0` to force a collection on every allocation
- Add `test_stress_gc` — a new GTest binary compiled unconditionally with `LOXPP_STRESS_GC` — covering strings, global/local functions, closures, recursion, and native calls under maximum GC pressure

## Test plan

- [x] All 11 tests pass locally (`ctest --output-on-failure` in the dev container)
- [x] `TestStressGC` passes with `LOXPP_STRESS_GC` always active (GC fires on every allocation)
- [x] CI `build-and-test` matrix runs `ctest` against both `debug` and `release` presets — covers Release regression testing automatically

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)