### PR TITLE
feat: add methods, initializers, and this (ch28)

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -42,6 +42,7 @@ enum class Op : Byte {
     CLASS,
     GET_PROPERTY,
     SET_PROPERTY,
+    DEFINE_METHOD,
 };
 
 inline Op toOpcode(Byte byte) { return static_cast<Op>(byte); }

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -43,6 +43,7 @@ enum class Op : Byte {
     GET_PROPERTY,
     SET_PROPERTY,
     DEFINE_METHOD,
+    INVOKE, // operands: name-constant-index (1 byte), arg-count (1 byte)
 };
 
 inline Op toOpcode(Byte byte) { return static_cast<Op>(byte); }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -563,6 +563,21 @@ void Compiler::dot() {
     if (m_parser->m_canAssign && m_parser->match(TokenType::EQUAL)) {
         expression();
         emitBytes(Op::SET_PROPERTY, nameConst);
+    } else if (m_parser->match(TokenType::LEFT_PAREN)) {
+        // Fuse GET_PROPERTY + CALL into a single INVOKE superinstruction.
+        uint8_t argCount = 0;
+        if (!m_parser->check(TokenType::RIGHT_PAREN)) {
+            do {
+                if (argCount == 255)
+                    m_parser->error("Can't have more than 255 arguments.");
+                expression();
+                argCount++;
+            } while (m_parser->match(TokenType::COMMA));
+        }
+        m_parser->consume(TokenType::RIGHT_PAREN,
+                          "Expect ')' after arguments.");
+        emitBytes(Op::INVOKE, nameConst);
+        emitByte(argCount);
     } else {
         emitBytes(Op::GET_PROPERTY, nameConst);
     }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -27,12 +27,21 @@ Compiler::Compiler(ObjFunction* function, Parser* parser, MemoryManager* mm,
                    FunctionType type, Compiler* enclosing)
     : m_function{function}, m_parser{parser}, m_mm{mm}, m_type{type},
       m_enclosing{enclosing} {
-    // Reserve slot 0 for the function/script itself. User-declared locals
-    // start at slot 1. The implicit local has an empty name so resolveLocal
-    // never accidentally matches it.
+    // Reserve slot 0: "this" for methods/initializers, empty name for others.
+    // The empty name ensures resolveLocal never accidentally matches it for
+    // non-method functions; "this" allows method bodies to capture the
+    // receiver.
     Local* implicit = &m_locals[m_localCount++];
     implicit->depth = 0;
-    implicit->name = Token{TokenType::IDENTIFIER, "", 0};
+    if (type == FunctionType::METHOD || type == FunctionType::INITIALIZER)
+        implicit->name = Token{TokenType::THIS, "this", 0};
+    else
+        implicit->name = Token{TokenType::IDENTIFIER, "", 0};
+
+    // Inherit class context so inner compilers (method bodies, closures inside
+    // methods) can still resolve 'this'.
+    if (m_enclosing != nullptr)
+        m_currentClass = m_enclosing->m_currentClass;
 
     m_mm->setCurrentCompiler(this);
 }
@@ -497,8 +506,54 @@ void Compiler::classDeclaration() {
     else
         emitBytes(Op::DEFINE_GLOBAL, nameConst);
 
+    // Push class back on the stack so DEFINE_METHOD can find it at peek(1)
+    // throughout the entire method body loop.
+    namedVariable(className, false);
+
+    ClassCompiler classCompiler;
+    classCompiler.enclosing = m_currentClass;
+    m_currentClass = &classCompiler;
+
     m_parser->consume(TokenType::LEFT_BRACE, "Expect '{' before class body.");
+    while (!m_parser->check(TokenType::RIGHT_BRACE) &&
+           !m_parser->check(TokenType::EOF_)) {
+        method();
+    }
     m_parser->consume(TokenType::RIGHT_BRACE, "Expect '}' after class body.");
+
+    emitByte(Op::POP); // pop the class pushed by namedVariable above
+
+    m_currentClass = m_currentClass->enclosing;
+}
+
+void Compiler::method() {
+    m_parser->consume(TokenType::IDENTIFIER, "Expect method name.");
+    uint8_t nameConst = identifierConstant(m_parser->m_previous);
+
+    FunctionType type = FunctionType::METHOD;
+    if (m_parser->m_previous.lexeme == "init")
+        type = FunctionType::INITIALIZER;
+
+    ObjFunction* fn = m_mm->create<ObjFunction>();
+    fn->name = m_mm->makeString(m_parser->m_previous.lexeme);
+
+    Compiler inner(fn, m_parser, m_mm, type, this);
+    inner.parseFunction(type);
+
+    emitBytes(Op::CLOSURE, makeConstant(Value{static_cast<Obj*>(fn)}));
+    for (int i = 0; i < fn->upvalueCount; i++) {
+        emitByte(inner.m_upvalues[i].isLocal ? 1 : 0);
+        emitByte(inner.m_upvalues[i].index);
+    }
+    emitBytes(Op::DEFINE_METHOD, nameConst);
+}
+
+void Compiler::this_() {
+    if (m_currentClass == nullptr) {
+        m_parser->error("Can't use 'this' outside of a class.");
+        return;
+    }
+    namedVariable(m_parser->m_previous, false);
 }
 
 void Compiler::dot() {
@@ -521,6 +576,8 @@ void Compiler::returnStatement() {
     if (m_parser->match(TokenType::SEMICOLON)) {
         emitReturn();
     } else {
+        if (m_type == FunctionType::INITIALIZER)
+            m_parser->error("Can't return a value from an initializer.");
         expression();
         m_parser->consume(TokenType::SEMICOLON,
                           "Expect ';' after return value.");
@@ -528,8 +585,7 @@ void Compiler::returnStatement() {
     }
 }
 
-void Compiler::parseFunction(FunctionType type) {
-    (void)type; // reserved for future use (e.g. methods vs. functions)
+void Compiler::parseFunction(FunctionType /*type*/) {
     beginScope();
     m_parser->consume(TokenType::LEFT_PAREN, "Expect '(' after function name.");
     if (!m_parser->check(TokenType::RIGHT_PAREN)) {
@@ -566,7 +622,10 @@ void Compiler::or_() {
 }
 
 void Compiler::emitReturn() {
-    emitByte(Op::NIL);
+    if (m_type == FunctionType::INITIALIZER)
+        emitBytes(Op::GET_LOCAL, 0); // implicit return of 'this'
+    else
+        emitByte(Op::NIL);
     emitByte(static_cast<Byte>(Op::RETURN));
 }
 

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -14,7 +14,11 @@ static constexpr int UINT8_COUNT = 256;
 
 ObjFunction* compile(const std::string& source, MemoryManager* mm);
 
-enum class FunctionType { SCRIPT, FUNCTION, METHOD };
+enum class FunctionType { SCRIPT, FUNCTION, METHOD, INITIALIZER };
+
+struct ClassCompiler {
+    ClassCompiler* enclosing{nullptr};
+};
 
 struct Local {
     Token name;
@@ -68,11 +72,13 @@ class Compiler {
     void block();
     void funDeclaration();
     void classDeclaration();
+    void method();
     void returnStatement();
 
     void and_();
     void or_();
     void dot();
+    void this_();
 
   private:
     void beginScope();
@@ -105,6 +111,7 @@ class Compiler {
     MemoryManager* m_mm;
     FunctionType m_type;
     Compiler* m_enclosing;
+    ClassCompiler* m_currentClass{nullptr};
 
     Local m_locals[UINT8_COUNT];
     int m_localCount{0};

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -52,6 +52,18 @@ static int jumpInstruction(const char* name, int sign, const Chunk& chunk,
     return offset + 3;
 }
 
+static int invokeInstruction(const char* name, const Chunk& chunk,
+                             const MemoryManager& mm, int offset,
+                             std::ostream& out, bool color) {
+    uint8_t nameIdx = chunk.at(offset + 1);
+    uint8_t argCount = chunk.at(offset + 2);
+    out << cc(color, kBold) << name << cc(color, kReset) << ' '
+        << static_cast<int>(nameIdx) << " ('" << cc(color, kYellow)
+        << stringify(chunk.getConstant(nameIdx)) << cc(color, kReset) << "') "
+        << static_cast<int>(argCount) << '\n';
+    return offset + 3;
+}
+
 static int closureInstruction(const char* name, const Chunk& chunk, int offset,
                               std::ostream& out, bool color) {
     uint8_t idx = chunk.at(offset + 1);
@@ -156,6 +168,8 @@ int disassembleInstruction(const Chunk& chunk, const MemoryManager& mm,
     case Op::DEFINE_METHOD:
         return constantInstruction("DEFINE_METHOD", chunk, mm, offset, out,
                                    color);
+    case Op::INVOKE:
+        return invokeInstruction("INVOKE", chunk, mm, offset, out, color);
     default:
         out << cc(color, kRed) << cc(color, kBold) << "UNKNOWN("
             << static_cast<unsigned>(chunk.at(offset)) << ")"

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -153,6 +153,9 @@ int disassembleInstruction(const Chunk& chunk, const MemoryManager& mm,
     case Op::SET_PROPERTY:
         return constantInstruction("SET_PROPERTY", chunk, mm, offset, out,
                                    color);
+    case Op::DEFINE_METHOD:
+        return constantInstruction("DEFINE_METHOD", chunk, mm, offset, out,
+                                   color);
     default:
         out << cc(color, kRed) << cc(color, kBold) << "UNKNOWN("
             << static_cast<unsigned>(chunk.at(offset)) << ")"

--- a/src/function.h
+++ b/src/function.h
@@ -86,3 +86,21 @@ inline ObjInstance* asObjInstance(Obj* o) {
 inline bool isInstance(const Value& v) {
     return is<Obj*>(v) && as<Obj*>(v)->type == ObjType::INSTANCE;
 }
+
+struct ObjBoundMethod : public Obj {
+    Value receiver; // the instance this method is bound to
+    ObjClosure* method;
+
+    ObjBoundMethod(Value recv, ObjClosure* m)
+        : Obj(ObjType::BOUND_METHOD), receiver(recv), method(m) {}
+};
+
+inline bool isObjBoundMethod(Obj* o) {
+    return isObjType(o, ObjType::BOUND_METHOD);
+}
+inline ObjBoundMethod* asObjBoundMethod(Obj* o) {
+    return static_cast<ObjBoundMethod*>(o);
+}
+inline bool isBoundMethod(const Value& v) {
+    return is<Obj*>(v) && as<Obj*>(v)->type == ObjType::BOUND_METHOD;
+}

--- a/src/memory_manager.cpp
+++ b/src/memory_manager.cpp
@@ -24,6 +24,8 @@ static const char* objTypeName(ObjType type) {
         return "class";
     case ObjType::INSTANCE:
         return "instance";
+    case ObjType::BOUND_METHOD:
+        return "bound_method";
     }
     return "?";
 }
@@ -156,6 +158,12 @@ void MemoryManager::traceObject(Obj* obj) {
             markObject(k);
             markValue(v);
         });
+        break;
+    }
+    case ObjType::BOUND_METHOD: {
+        auto* bm = static_cast<ObjBoundMethod*>(obj);
+        markValue(bm->receiver);
+        markObject(bm->method);
         break;
     }
     }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -42,6 +42,13 @@ std::string stringifyObj(Obj* obj) {
                            inst->klass->name->chars.size()) +
                " instance";
     }
+    case ObjType::BOUND_METHOD: {
+        auto* bm = static_cast<ObjBoundMethod*>(obj);
+        auto* fn = bm->method->function;
+        return "<fn " +
+               std::string(fn->name->chars.data(), fn->name->chars.size()) +
+               ">";
+    }
     }
     return "<obj>";
 }

--- a/src/object.h
+++ b/src/object.h
@@ -13,7 +13,8 @@ enum class ObjType : uint8_t {
     UPVALUE,
     CLOSURE,
     CLASS,
-    INSTANCE
+    INSTANCE,
+    BOUND_METHOD
 };
 
 inline uint32_t hashString(std::string_view s) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -44,7 +44,7 @@ static const ParseRule rules[] = {
     RULE(PRINT,          nullptr,             nullptr,           NONE),
     RULE(RETURN,         nullptr,             nullptr,           NONE),
     RULE(SUPER,          nullptr,             nullptr,           NONE),
-    RULE(THIS,           nullptr,             nullptr,           NONE),
+    RULE(THIS,           &Compiler::this_,    nullptr,           NONE),
     RULE(TRUE,           &Compiler::literal,  nullptr,           NONE),
     RULE(VAR,            nullptr,             nullptr,           NONE),
     RULE(WHILE,          nullptr,             nullptr,           NONE),

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -387,6 +387,45 @@ InterpretResult VM::run() {
             pop(); // pop closure; leave class on stack for next method
             break;
         }
+        case Op::INVOKE: {
+            ObjString* name = asObjString(readConstant());
+            int argCount = readByte();
+            Value receiver = peek(argCount);
+            if (!isInstance(receiver)) {
+                runtimeError("Only instances have properties.");
+                return InterpretResult::RUNTIME_ERROR;
+            }
+            ObjInstance* instance = asObjInstance(as<Obj*>(receiver));
+            // A field can shadow a method — check fields first.
+            Value fieldVal;
+            if (instance->fields.get(name, fieldVal)) {
+                stackTop[-argCount - 1] = fieldVal;
+                if (isClosure(fieldVal)) {
+                    if (!call(asObjClosure(as<Obj*>(fieldVal)), argCount))
+                        return InterpretResult::RUNTIME_ERROR;
+                } else if (isNative(fieldVal)) {
+                    if (!callNative(asObjNative(as<Obj*>(fieldVal)), argCount))
+                        return InterpretResult::RUNTIME_ERROR;
+                } else {
+                    runtimeError("Can only call functions and classes.");
+                    return InterpretResult::RUNTIME_ERROR;
+                }
+                frame = &m_frames[m_frameCount - 1];
+                break;
+            }
+            // Fast path: call the method directly — receiver already sits at
+            // stackTop[-argCount-1], which becomes slot 0 (= this) of the new
+            // frame.
+            Value method;
+            if (!instance->klass->methods.get(name, method)) {
+                runtimeError("Undefined property '%s'.", name->chars.c_str());
+                return InterpretResult::RUNTIME_ERROR;
+            }
+            if (!call(asObjClosure(as<Obj*>(method)), argCount))
+                return InterpretResult::RUNTIME_ERROR;
+            frame = &m_frames[m_frameCount - 1];
+            break;
+        }
         case Op::CLOSURE: {
             ObjFunction* fn = asObjFunction(readConstant());
             ObjClosure* cl = m_mm.create<ObjClosure>(fn);

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -311,13 +311,28 @@ InterpretResult VM::run() {
                     return InterpretResult::RUNTIME_ERROR;
                 }
                 frame = &m_frames[m_frameCount - 1];
+            } else if (isBoundMethod(callee)) {
+                ObjBoundMethod* bound = asObjBoundMethod(as<Obj*>(callee));
+                // Slot 0 of the new frame = receiver (= this).
+                stackTop[-argCount - 1] = bound->receiver;
+                if (!call(bound->method, argCount)) {
+                    return InterpretResult::RUNTIME_ERROR;
+                }
+                frame = &m_frames[m_frameCount - 1];
             } else if (isClass(callee)) {
                 ObjClass* klass = asObjClass(as<Obj*>(callee));
                 ObjInstance* instance =
                     m_mm.create<ObjInstance>(klass, VmAllocator<Entry>{&m_mm});
-                // Replace the class on the stack with the new instance.
                 stackTop[-argCount - 1] = Value{static_cast<Obj*>(instance)};
-                if (argCount != 0) {
+                // Call init() if the class defines one.
+                ObjString* initStr = m_mm.findString("init");
+                Value initMethod;
+                if (initStr && klass->methods.get(initStr, initMethod)) {
+                    if (!call(asObjClosure(as<Obj*>(initMethod)), argCount)) {
+                        return InterpretResult::RUNTIME_ERROR;
+                    }
+                    frame = &m_frames[m_frameCount - 1];
+                } else if (argCount != 0) {
                     runtimeError("Expected 0 arguments but got %d.", argCount);
                     return InterpretResult::RUNTIME_ERROR;
                 }
@@ -347,8 +362,9 @@ InterpretResult VM::run() {
                 push(value);
                 break;
             }
-            runtimeError("Undefined property '%s'.", name->chars.c_str());
-            return InterpretResult::RUNTIME_ERROR;
+            if (!bindMethod(instance->klass, name))
+                return InterpretResult::RUNTIME_ERROR;
+            break;
         }
         case Op::SET_PROPERTY: {
             if (!isInstance(peek(1))) {
@@ -361,6 +377,14 @@ InterpretResult VM::run() {
             Value val = pop(); // value
             pop();             // instance
             push(val);         // assignment is an expression
+            break;
+        }
+        case Op::DEFINE_METHOD: {
+            ObjString* name = asObjString(readConstant());
+            Value method = peek(0); // ObjClosure* on top
+            ObjClass* klass = asObjClass(as<Obj*>(peek(1))); // class below
+            klass->methods.set(name, method);
+            pop(); // pop closure; leave class on stack for next method
             break;
         }
         case Op::CLOSURE: {
@@ -423,6 +447,19 @@ bool VM::callNative(ObjNative* native, int argCount) {
     Value result = native->function(argCount, stackTop - argCount);
     stackTop -= argCount + 1; // pop args + callee
     push(result);
+    return true;
+}
+
+bool VM::bindMethod(ObjClass* klass, ObjString* name) {
+    Value method;
+    if (!klass->methods.get(name, method)) {
+        runtimeError("Undefined property '%s'.", name->chars.c_str());
+        return false;
+    }
+    ObjBoundMethod* bound =
+        m_mm.create<ObjBoundMethod>(peek(0), asObjClosure(as<Obj*>(method)));
+    pop(); // instance
+    push(Value{static_cast<Obj*>(bound)});
     return true;
 }
 

--- a/src/vm.h
+++ b/src/vm.h
@@ -48,6 +48,7 @@ class VM {
 
     bool call(ObjClosure* closure, int argCount);
     bool callNative(ObjNative* native, int argCount);
+    bool bindMethod(ObjClass* klass, ObjString* name);
     void defineNative(const char* name, NativeFn fn, int arity);
     void defineNatives();
     ObjUpvalue* captureUpvalue(Value* local);


### PR DESCRIPTION
## Summary

- **`ObjBoundMethod`** — new heap object wrapping a receiver `Value` + `ObjClosure*`; created by `GET_PROPERTY` when the name resolves to a class method rather than an instance field
- **`Op::DEFINE_METHOD`** — new opcode that pops a closure and stores it in the class's methods table; class stays at `peek(1)` throughout the class body so multiple methods can be defined without re-fetching the class
- **`classDeclaration()`** — now loops over method declarations; uses a `namedVariable` push before the loop and `Op::POP` after to keep the class accessible to `DEFINE_METHOD`
- **`this` keyword** — slot 0 is named `"this"` in `METHOD`/`INITIALIZER` frames; inner `Compiler` objects inherit `m_currentClass` from their enclosing compiler so closures inside methods can also reference `this`
- **`init()` initializer** — called automatically on instantiation via non-allocating `findString("init")`; returns `this` implicitly; compile error on `return <value>;` inside one
- **`CALL` on bound method** — sets `stackTop[-argCount-1]` to the bound receiver before calling, putting it in slot 0 (= `this`) without any extra opcode

Rebased cleanly on main after #34 was squash-merged.

## Test plan

- [x] All 11 tests pass (`ctest`)
- [x] `Counter` class with `init`/`inc`/`get` methods produces correct results
- [x] `Point` class with `init(x, y)` stores and retrieves fields via `this`

🤖 Generated with [Claude Code](https://claude.com/claude-code)