### PR TITLE
feat: add % (modulo) operator

### DIFF
--- a/spec/01-lexical.md
+++ b/spec/01-lexical.md
@@ -55,6 +55,7 @@ There are no block comments.
 | `;` | SEMICOLON |
 | `/` | SLASH |
 | `*` | STAR |
+| `%` | PERCENT |
 
 ### One-or-Two-Character Tokens
 

--- a/spec/02-syntax.md
+++ b/spec/02-syntax.md
@@ -73,7 +73,7 @@ comparison     ::= term ( ( ">" | ">=" | "<" | "<=" ) term )* ;
 
 term           ::= factor ( ( "-" | "+" ) factor )* ;
 
-factor         ::= unary ( ( "/" | "*" ) unary )* ;
+factor         ::= unary ( ( "/" | "*" | "%" ) unary )* ;
 
 unary          ::= ( "!" | "-" ) unary
                  | call ;
@@ -109,7 +109,7 @@ Operators within the same group are left-associative unless noted otherwise.
 | 4 | `==` `!=` | Left |
 | 5 | `<` `<=` `>` `>=` | Left |
 | 6 | `+` `-` | Left |
-| 7 | `*` `/` | Left |
+| 7 | `*` `/` `%` | Left |
 | 8 | `!` `-` (unary) | Right (prefix) |
 | 9 (highest) | `()` (function call), `.` (property access), `[]` (index) | Left |
 

--- a/spec/04-semantics.md
+++ b/spec/04-semantics.md
@@ -90,6 +90,7 @@ parsing precedence.
 | `a - b` | Both Numbers | Difference |
 | `a * b` | Both Numbers | Product |
 | `a / b` | Both Numbers | Quotient |
+| `a % b` | Both Numbers | Remainder (floor-division semantics) |
 | `-a` | Number | Negation |
 
 Any violation of the type requirement is a **runtime error**.
@@ -100,6 +101,8 @@ operand.
 
 Division follows IEEE 754; dividing by zero produces `Infinity` or
 `-Infinity` (not an error).
+
+Modulo (`%`) is computed as `fmod(a, b)` adjusted so the result has the same sign as `b` (floor-division semantics, same as Python and Lua). `a % 0` produces `NaN` (consistent with `a / 0` producing `Infinity`).
 
 ### Comparison
 

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -22,6 +22,7 @@ enum class Op : Byte {
     SUBTRACT,
     MULTIPLY,
     DIVIDE,
+    MODULO,
     NOT,
     PRINT,
     POP,

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -136,6 +136,9 @@ void Compiler::binary() {
     case TokenType::SLASH:
         emitByte(Op::DIVIDE);
         break;
+    case TokenType::PERCENT:
+        emitByte(Op::MODULO);
+        break;
     default:
         return; // Unreachable.
     }

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -122,6 +122,8 @@ int disassembleInstruction(const Chunk& chunk, const MemoryManager& mm,
         return simpleInstruction("MULTIPLY", offset, out, color);
     case Op::DIVIDE:
         return simpleInstruction("DIVIDE", offset, out, color);
+    case Op::MODULO:
+        return simpleInstruction("MODULO", offset, out, color);
     case Op::NOT:
         return simpleInstruction("NOT", offset, out, color);
     case Op::PRINT:

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -22,6 +22,7 @@ static const ParseRule rules[] = {
     RULE(SEMICOLON,      nullptr,             nullptr,           NONE),
     RULE(SLASH,          nullptr,             &Compiler::binary, FACTOR),
     RULE(STAR,           nullptr,             &Compiler::binary, FACTOR),
+    RULE(PERCENT,        nullptr,             &Compiler::binary, FACTOR),
     RULE(BANG,           &Compiler::unary,    nullptr,           NONE),
     RULE(BANG_EQUAL,     nullptr,             &Compiler::binary, EQUALITY),
     RULE(EQUAL,          nullptr,             nullptr,           NONE),

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -68,6 +68,8 @@ Token Scanner::scanOneToken() {
         return makeToken(TokenType::STAR);
     case '/':
         return makeToken(TokenType::SLASH);
+    case '%':
+        return makeToken(TokenType::PERCENT);
     case '!':
         return makeToken(match('=') ? TokenType::BANG_EQUAL : TokenType::BANG);
     case '=':

--- a/src/token.h
+++ b/src/token.h
@@ -19,6 +19,7 @@ enum class TokenType : int {
     SEMICOLON,
     SLASH,
     STAR,
+    PERCENT,
 
     // One or two character tokens.
     BANG,

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -232,6 +232,19 @@ InterpretResult VM::run() {
             BINARY_OP(Number, /);
             break;
         }
+        case Op::MODULO: {
+            if (!is<Number>(peek(0)) || !is<Number>(peek(1))) {
+                runtimeError("Operands must be numbers.");
+                return InterpretResult::RUNTIME_ERROR;
+            }
+            Number b = as<Number>(pop());
+            Number a = as<Number>(pop());
+            Number result = std::fmod(a, b);
+            // Floor-division semantics: result has same sign as b (Python/Lua behavior)
+            if (result != 0 && (result < 0) != (b < 0)) result += b;
+            push(from<Number>(result));
+            break;
+        }
         case Op::NOT: {
             push(from<bool>(!pop()));
             break;

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -240,8 +240,10 @@ InterpretResult VM::run() {
             Number b = as<Number>(pop());
             Number a = as<Number>(pop());
             Number result = std::fmod(a, b);
-            // Floor-division semantics: result has same sign as b (Python/Lua behavior)
-            if (result != 0 && (result < 0) != (b < 0)) result += b;
+            // Floor-division semantics: result has same sign as b (Python/Lua
+            // behavior)
+            if (result != 0 && (result < 0) != (b < 0))
+                result += b;
             push(from<Number>(result));
             break;
         }

--- a/test/test_parser_bytecode.cpp
+++ b/test/test_parser_bytecode.cpp
@@ -209,3 +209,15 @@ TEST_F(FunctionBytecodeTest, FunctionWithLocalVar_InnerChunk) {
                            "3: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
+
+TEST_F(ParserBytecodeTest, Arithmetic_Modulo) {
+    std::string expr = "10 % 3";
+    std::string bytecode = compile_to_bytecode(expr);
+    std::string expected = "0: CONSTANT 0 ('10')\n"
+                           "2: CONSTANT 1 ('3')\n"
+                           "4: MODULO\n"
+                           "5: POP\n"
+                           "6: NIL\n"
+                           "7: RETURN\n";
+    EXPECT_EQ(trim(bytecode), trim(expected));
+}

--- a/test/test_scanner.cpp
+++ b/test/test_scanner.cpp
@@ -31,9 +31,9 @@ TEST_F(ScannerTest, EmptySource) {
 }
 
 TEST_F(ScannerTest, SingleCharacterTokens) {
-    const char* source = "(){},.-+;*";
+    const char* source = "(){},.-+;*%";
     auto tokens = scanTokens(source);
-    ASSERT_EQ(tokens.size(), 11); // 10 tokens + EOF
+    ASSERT_EQ(tokens.size(), 12); // 11 tokens + EOF
     EXPECT_EQ(tokens[0].type, TokenType::LEFT_PAREN);
     EXPECT_EQ(tokens[1].type, TokenType::RIGHT_PAREN);
     EXPECT_EQ(tokens[2].type, TokenType::LEFT_BRACE);
@@ -44,6 +44,7 @@ TEST_F(ScannerTest, SingleCharacterTokens) {
     EXPECT_EQ(tokens[7].type, TokenType::PLUS);
     EXPECT_EQ(tokens[8].type, TokenType::SEMICOLON);
     EXPECT_EQ(tokens[9].type, TokenType::STAR);
+    EXPECT_EQ(tokens[10].type, TokenType::PERCENT);
 }
 
 TEST_F(ScannerTest, OneOrTwoCharacterTokens) {
@@ -128,14 +129,6 @@ TEST_F(ScannerTest, CommentHandling) {
     EXPECT_EQ(tokens[2].type, TokenType::EOF_);
 }
 
-TEST_F(ScannerTest, PercentToken) {
-    const char* source = "%";
-    auto tokens = scanTokens(source);
-    ASSERT_EQ(tokens.size(), 2); // 1 token + EOF
-    EXPECT_EQ(tokens[0].type, TokenType::PERCENT);
-    EXPECT_EQ(tokens[0].lexeme, "%");
-    EXPECT_EQ(tokens[1].type, TokenType::EOF_);
-}
 
 int main(int argc, char** argv) {
     testing::InitGoogleTest(&argc, argv);

--- a/test/test_scanner.cpp
+++ b/test/test_scanner.cpp
@@ -129,7 +129,6 @@ TEST_F(ScannerTest, CommentHandling) {
     EXPECT_EQ(tokens[2].type, TokenType::EOF_);
 }
 
-
 int main(int argc, char** argv) {
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/test/test_scanner.cpp
+++ b/test/test_scanner.cpp
@@ -128,6 +128,15 @@ TEST_F(ScannerTest, CommentHandling) {
     EXPECT_EQ(tokens[2].type, TokenType::EOF_);
 }
 
+TEST_F(ScannerTest, PercentToken) {
+    const char* source = "%";
+    auto tokens = scanTokens(source);
+    ASSERT_EQ(tokens.size(), 2); // 1 token + EOF
+    EXPECT_EQ(tokens[0].type, TokenType::PERCENT);
+    EXPECT_EQ(tokens[0].lexeme, "%");
+    EXPECT_EQ(tokens[1].type, TokenType::EOF_);
+}
+
 int main(int argc, char** argv) {
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/test/test_vm_runtime.cpp
+++ b/test/test_vm_runtime.cpp
@@ -529,3 +529,39 @@ TEST_F(NativeTest, StackCleanAfterNativeCall) {
     ASSERT_EQ(h.run("str(1); str(2); str(3);"), InterpretResult::OK);
     EXPECT_EQ(h.stackDepth(), 0);
 }
+
+// ===========================================================================
+// Modulo operator tests
+// ===========================================================================
+
+class ModuloTest : public ::testing::Test {};
+
+TEST_F(ModuloTest, BasicModulo) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("10 % 3;"), InterpretResult::OK);
+    EXPECT_NEAR(as<Number>(h.lastResult()), 1.0, 1e-9);
+}
+
+TEST_F(ModuloTest, FloatModulo) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("7.5 % 2.5;"), InterpretResult::OK);
+    EXPECT_NEAR(as<Number>(h.lastResult()), 0.0, 1e-9);
+}
+
+TEST_F(ModuloTest, NegativeDividend_FloorSemantics) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("-7 % 3;"), InterpretResult::OK);
+    EXPECT_NEAR(as<Number>(h.lastResult()), 2.0, 1e-9);
+}
+
+TEST_F(ModuloTest, NegativeDivisor_FloorSemantics) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("7 % -3;"), InterpretResult::OK);
+    EXPECT_NEAR(as<Number>(h.lastResult()), -2.0, 1e-9);
+}
+
+TEST_F(ModuloTest, ZeroDividend) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("0 % 5;"), InterpretResult::OK);
+    EXPECT_NEAR(as<Number>(h.lastResult()), 0.0, 1e-9);
+}


### PR DESCRIPTION
## Summary 

- Adds  operator at  precedence (same as  and )
- Floor-division semantics: ,  (Python/Lua behavior)
- Float support:  via   
-  →  (consistent with  → )
- Spec updated: lexical grammar, syntax grammar, and semantics doc

## Test plan 

- [ ] `test_scanner`: PERCENT token lexed correctly
- [ ] `test_parser_bytecode`: emits  opcode at FACTOR precedence
- [ ] `test_vm_runtime` (5 cases): basic, float, negative dividend, negative divisor, zero dividend
- [ ]  `cmake --build build && ctest --test-dir build` - all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
