### PR TITLE
fix: save m_canAssign before compiling subscript index expression

### DIFF
--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -768,9 +768,9 @@ void Compiler::listLiteral() {
 }
 
 void Compiler::subscript() {
-    bool canAssign = m_parser->m_canAssign; // save: compiling the index expression
-                                             // clobbers m_canAssign via nested
-                                             // parsePrecedence calls.
+    bool canAssign = m_parser->m_canAssign; // save: compiling the index
+                                            // expression clobbers m_canAssign
+                                            // via nested parsePrecedence calls.
     expression(); // compile index
     m_parser->consume(TokenType::RIGHT_BRACKET, "Expect ']' after index.");
     if (canAssign && m_parser->match(TokenType::EQUAL)) {

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -771,7 +771,7 @@ void Compiler::subscript() {
     bool canAssign = m_parser->m_canAssign; // save: compiling the index
                                             // expression clobbers m_canAssign
                                             // via nested parsePrecedence calls.
-    expression(); // compile index
+    expression();                           // compile index
     m_parser->consume(TokenType::RIGHT_BRACKET, "Expect ']' after index.");
     if (canAssign && m_parser->match(TokenType::EQUAL)) {
         expression(); // compile RHS

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -768,9 +768,12 @@ void Compiler::listLiteral() {
 }
 
 void Compiler::subscript() {
+    bool canAssign = m_parser->m_canAssign; // save: compiling the index expression
+                                             // clobbers m_canAssign via nested
+                                             // parsePrecedence calls.
     expression(); // compile index
     m_parser->consume(TokenType::RIGHT_BRACKET, "Expect ']' after index.");
-    if (m_parser->m_canAssign && m_parser->match(TokenType::EQUAL)) {
+    if (canAssign && m_parser->match(TokenType::EQUAL)) {
         expression(); // compile RHS
         emitByte(Op::SET_INDEX);
     } else {

--- a/test/test_list.cpp
+++ b/test/test_list.cpp
@@ -76,6 +76,51 @@ TEST(List, IndexSetIsExpression) {
     EXPECT_EQ(h.getGlobalStr("r"), "42");
 }
 
+TEST(List, IndexSetExpressionIndex) {
+    // Bug: compiling the index expression (e.g. j + 1) clobbered m_canAssign,
+    // so xs[j + 1] = v was miscompiled as GET_INDEX followed by a stray '='.
+    VMTestHarness h;
+    ASSERT_EQ(h.run(R"(
+        var xs = [10, 20, 30];
+        var j = 0;
+        xs[j + 1] = 99;
+        var r = xs[1];
+    )"),
+              InterpretResult::OK);
+    EXPECT_EQ(h.getGlobalStr("r"), "99");
+}
+
+TEST(List, IndexSetExpressionIndexInsideFunction) {
+    // Same as IndexSetExpressionIndex but inside a function scope (exercises
+    // local-variable index paths in the compiler).
+    VMTestHarness h;
+    ASSERT_EQ(h.run(R"(
+        fun setAt(xs, j, v) { xs[j + 1] = v; }
+        var xs = [10, 20, 30];
+        setAt(xs, 0, 99);
+        var r = xs[1];
+    )"),
+              InterpretResult::OK);
+    EXPECT_EQ(h.getGlobalStr("r"), "99");
+}
+
+TEST(List, IndexSetSwapPattern) {
+    // In-place swap via expression indices — the core of bubble / insertion sort.
+    VMTestHarness h;
+    ASSERT_EQ(h.run(R"(
+        var xs = [1, 2, 3];
+        var j = 0;
+        var t = xs[j];
+        xs[j]     = xs[j + 1];
+        xs[j + 1] = t;
+        var r0 = xs[0];
+        var r1 = xs[1];
+    )"),
+              InterpretResult::OK);
+    EXPECT_EQ(h.getGlobalStr("r0"), "2");
+    EXPECT_EQ(h.getGlobalStr("r1"), "1");
+}
+
 TEST(List, IndexSetAllElements) {
     VMTestHarness h;
     ASSERT_EQ(h.run(R"(

--- a/test/test_list.cpp
+++ b/test/test_list.cpp
@@ -105,7 +105,8 @@ TEST(List, IndexSetExpressionIndexInsideFunction) {
 }
 
 TEST(List, IndexSetSwapPattern) {
-    // In-place swap via expression indices — the core of bubble / insertion sort.
+    // In-place swap via expression indices — the core of bubble / insertion
+    // sort.
     VMTestHarness h;
     ASSERT_EQ(h.run(R"(
         var xs = [1, 2, 3];


### PR DESCRIPTION
## Summary

- `subscript()` in `compiler.cpp` read `m_canAssign` *after* calling `expression()` to compile the index. Compiling a non-trivial index like `j + 1` calls `parsePrecedence(FACTOR)` internally, which resets `m_canAssign = false`. The assignment check then saw `false` and emitted `GET_INDEX` instead of `SET_INDEX`, silently miscompiling `xs[j + 1] = v`.
- Fix: capture `m_canAssign` into a local before calling `expression()`, use the saved value for the check.
- Simple indices (`xs[0] = v`, `xs[i] = v`) were unaffected because a literal or bare variable parses without a nested `parsePrecedence` call that would clobber the flag.

## Test plan

- [ ] `IndexSetExpressionIndex` — `xs[j + 1] = v` at script scope compiles and runs correctly
- [ ] `IndexSetExpressionIndexInsideFunction` — same pattern inside a function scope
- [ ] `IndexSetSwapPattern` — in-place swap (`var t = xs[j]; xs[j] = xs[j+1]; xs[j+1] = t`) works end-to-end
- [ ] Full test suite (`ctest`) — 15/15 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)