### PR TITLE
feat: add math stdlib global object

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,17 +20,18 @@ add_compile_options(-Wno-c99-designator)
 
 include_directories(${PROJECT_SOURCE_DIR}/src)
 
-add_executable(loxpp 
-    src/main.cpp 
-    src/chunk.cpp 
+add_executable(loxpp
+    src/main.cpp
+    src/chunk.cpp
     src/debug.cpp
-    src/value.cpp 
+    src/value.cpp
     src/object.cpp
     src/table.cpp
     src/memory_manager.cpp
-    src/vm.cpp 
-    src/scanner.cpp 
-    src/token.cpp 
+    src/math.cpp
+    src/vm.cpp
+    src/scanner.cpp
+    src/token.cpp
     src/compiler.cpp
     src/parser.cpp
 )

--- a/examples/math_demo.lox
+++ b/examples/math_demo.lox
@@ -1,0 +1,28 @@
+// RUN: loxpp %s | FileCheck %s
+
+// CHECK: 1.41421
+print math.sqrt(2);
+
+// CHECK: 1024
+print math.pow(2, 10);
+
+// CHECK: 3.14159
+print math.pi;
+
+// CHECK: 1
+print math.log(math.e);
+
+// CHECK: 3
+print math.min(3, 7);
+
+// CHECK: 7
+print math.max(3, 7);
+
+// CHECK: 0
+print math.floor(0.9);
+
+// CHECK: 1
+print math.ceil(0.1);
+
+// CHECK: 2
+print math.abs(-2);

--- a/src/math.cpp
+++ b/src/math.cpp
@@ -1,0 +1,85 @@
+#include "math.h"
+
+#include "native.h"
+#include "value.h"
+
+#include <cmath>
+#include <limits>
+
+// ---------------------------------------------------------------------------
+// Template helpers — replace error-prone macros with typed function templates.
+// Each template is instantiated once per math function via a function pointer
+// parameter, so the validation logic is shared and the compiler inlines freely.
+// ---------------------------------------------------------------------------
+
+using UnaryFn = double (*)(double);
+using BinaryFn = double (*)(double, double);
+
+template <UnaryFn F>
+static Value unaryMath(int /*argc*/, Value* args) {
+    if (!is<Number>(args[0])) {
+        nativeRuntimeError("math function argument must be a number.");
+        return from<Nil>(Nil{});
+    }
+    return from<Number>(F(as<Number>(args[0])));
+}
+
+template <BinaryFn F>
+static Value binaryMath(int /*argc*/, Value* args) {
+    if (!is<Number>(args[0]) || !is<Number>(args[1])) {
+        nativeRuntimeError("math function arguments must be numbers.");
+        return from<Nil>(Nil{});
+    }
+    return from<Number>(F(as<Number>(args[0]), as<Number>(args[1])));
+}
+
+// Thin wrappers that resolve overloaded std:: functions to their double
+// signatures, giving unambiguous function pointers for template instantiation.
+static double wrap_abs(double x) { return std::abs(x); }
+static double wrap_ceil(double x) { return std::ceil(x); }
+static double wrap_floor(double x) { return std::floor(x); }
+static double wrap_round(double x) { return std::round(x); }
+static double wrap_sqrt(double x) { return std::sqrt(x); }
+static double wrap_cbrt(double x) { return std::cbrt(x); }
+static double wrap_exp(double x) { return std::exp(x); }
+static double wrap_log(double x) { return std::log(x); }
+static double wrap_log2(double x) { return std::log2(x); }
+static double wrap_log10(double x) { return std::log10(x); }
+static double wrap_sin(double x) { return std::sin(x); }
+static double wrap_cos(double x) { return std::cos(x); }
+static double wrap_tan(double x) { return std::tan(x); }
+static double wrap_asin(double x) { return std::asin(x); }
+static double wrap_acos(double x) { return std::acos(x); }
+static double wrap_atan(double x) { return std::atan(x); }
+static double wrap_pow(double x, double y) { return std::pow(x, y); }
+static double wrap_atan2(double y, double x) { return std::atan2(y, x); }
+static double wrap_hypot(double x, double y) { return std::hypot(x, y); }
+static double wrap_fmin(double x, double y) { return std::fmin(x, y); }
+static double wrap_fmax(double x, double y) { return std::fmax(x, y); }
+
+// ---------------------------------------------------------------------------
+// Registration tables consumed by VM::defineMathObject()
+// ---------------------------------------------------------------------------
+
+const MathFnEntry kMathFunctions[] = {
+    {"abs", unaryMath<wrap_abs>, 1},      {"ceil", unaryMath<wrap_ceil>, 1},
+    {"floor", unaryMath<wrap_floor>, 1},  {"round", unaryMath<wrap_round>, 1},
+    {"sqrt", unaryMath<wrap_sqrt>, 1},    {"cbrt", unaryMath<wrap_cbrt>, 1},
+    {"exp", unaryMath<wrap_exp>, 1},      {"log", unaryMath<wrap_log>, 1},
+    {"log2", unaryMath<wrap_log2>, 1},    {"log10", unaryMath<wrap_log10>, 1},
+    {"sin", unaryMath<wrap_sin>, 1},      {"cos", unaryMath<wrap_cos>, 1},
+    {"tan", unaryMath<wrap_tan>, 1},      {"asin", unaryMath<wrap_asin>, 1},
+    {"acos", unaryMath<wrap_acos>, 1},    {"atan", unaryMath<wrap_atan>, 1},
+    {"pow", binaryMath<wrap_pow>, 2},     {"atan2", binaryMath<wrap_atan2>, 2},
+    {"hypot", binaryMath<wrap_hypot>, 2}, {"min", binaryMath<wrap_fmin>, 2},
+    {"max", binaryMath<wrap_fmax>, 2},
+};
+const std::size_t kMathFunctionCount = std::size(kMathFunctions);
+
+const MathConstEntry kMathConstants[] = {
+    {"pi", M_PI},
+    {"e", M_E},
+    {"inf", std::numeric_limits<double>::infinity()},
+    {"nan", std::numeric_limits<double>::quiet_NaN()},
+};
+const std::size_t kMathConstantCount = std::size(kMathConstants);

--- a/src/math.h
+++ b/src/math.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "native.h"
+
+#include <cstddef>
+
+struct MathFnEntry {
+    const char* name;
+    NativeFn fn;
+    int arity;
+};
+
+struct MathConstEntry {
+    const char* name;
+    double value;
+};
+
+extern const MathFnEntry kMathFunctions[];
+extern const std::size_t kMathFunctionCount;
+
+extern const MathConstEntry kMathConstants[];
+extern const std::size_t kMathConstantCount;

--- a/src/native.h
+++ b/src/native.h
@@ -6,6 +6,10 @@
 // Signature for all native (C++) functions callable from Lox.
 using NativeFn = Value (*)(int argCount, Value* args);
 
+// Signal a runtime error from inside a native function.
+// The VM checks this flag after every native call and surfaces the message.
+void nativeRuntimeError(const char* msg);
+
 struct ObjNative : public Obj {
     NativeFn function;
     int arity; // expected argument count; -1 = variadic (any count accepted)

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -7,13 +7,15 @@
 #include "scanner.h"
 #include "compiler.h"
 
+#include "math.h"
+
 #include <cmath>
+#include <cstddef>
 #include <cstdio>
 #include <cstdarg>
 #include <ctime>
 #include <functional>
 #include <iostream>
-#include <limits>
 #include <string>
 #include <unistd.h>
 
@@ -35,7 +37,7 @@ static MemoryManager* s_currentMM = nullptr;
 static bool s_nativeError = false;
 static std::string s_nativeErrorMsg;
 
-static void nativeRuntimeError(const char* msg) {
+void nativeRuntimeError(const char* msg) {
     s_nativeError = true;
     s_nativeErrorMsg = msg;
 }
@@ -62,63 +64,6 @@ static Value lenNative(int /*argCount*/, Value* args) {
     auto* list = asObjList(as<Obj*>(args[0]));
     return from<Number>(static_cast<double>(list->elements.size()));
 }
-
-// ---------------------------------------------------------------------------
-// math object — native implementations
-// ---------------------------------------------------------------------------
-
-static bool mathCheckNum1(Value* args) {
-    if (!is<Number>(args[0])) {
-        nativeRuntimeError("math function argument must be a number.");
-        return false;
-    }
-    return true;
-}
-static bool mathCheckNum2(Value* args) {
-    if (!is<Number>(args[0]) || !is<Number>(args[1])) {
-        nativeRuntimeError("math function arguments must be numbers.");
-        return false;
-    }
-    return true;
-}
-
-#define MATH_UNARY(name, fn)                                                   \
-    static Value name(int /*argc*/, Value* args) {                             \
-        if (!mathCheckNum1(args)) return from<Nil>(Nil{});                     \
-        return from<Number>(fn(as<Number>(args[0])));                          \
-    }
-
-#define MATH_BINARY(name, fn)                                                  \
-    static Value name(int /*argc*/, Value* args) {                             \
-        if (!mathCheckNum2(args)) return from<Nil>(Nil{});                     \
-        return from<Number>(fn(as<Number>(args[0]), as<Number>(args[1])));     \
-    }
-
-MATH_UNARY(mathAbsNative,   std::abs)
-MATH_UNARY(mathCeilNative,  std::ceil)
-MATH_UNARY(mathFloorNative, std::floor)
-MATH_UNARY(mathRoundNative, std::round)
-MATH_UNARY(mathSqrtNative,  std::sqrt)
-MATH_UNARY(mathCbrtNative,  std::cbrt)
-MATH_UNARY(mathExpNative,   std::exp)
-MATH_UNARY(mathLogNative,   std::log)
-MATH_UNARY(mathLog2Native,  std::log2)
-MATH_UNARY(mathLog10Native, std::log10)
-MATH_UNARY(mathSinNative,   std::sin)
-MATH_UNARY(mathCosNative,   std::cos)
-MATH_UNARY(mathTanNative,   std::tan)
-MATH_UNARY(mathAsinNative,  std::asin)
-MATH_UNARY(mathAcosNative,  std::acos)
-MATH_UNARY(mathAtanNative,  std::atan)
-
-MATH_BINARY(mathPowNative,   std::pow)
-MATH_BINARY(mathAtan2Native, std::atan2)
-MATH_BINARY(mathHypotNative, std::hypot)
-MATH_BINARY(mathMinNative,   std::fmin)
-MATH_BINARY(mathMaxNative,   std::fmax)
-
-#undef MATH_UNARY
-#undef MATH_BINARY
 
 InterpretResult VM::interpret(const std::string& source) {
     ObjFunction* fn = compile(source, &m_mm);
@@ -755,61 +700,31 @@ void VM::defineMathObject() {
     // a. Create the Math class (just a nominal holder for the instance)
     ObjString* className = m_mm.makeString("Math");
     push(Value{static_cast<Obj*>(className)}); // root className
-    ObjClass* klass = m_mm.create<ObjClass>(className, VmAllocator<Entry>{&m_mm});
+    ObjClass* klass =
+        m_mm.create<ObjClass>(className, VmAllocator<Entry>{&m_mm});
     push(Value{static_cast<Obj*>(klass)}); // root klass
 
     // b. Create the instance
     ObjInstance* instance =
         m_mm.create<ObjInstance>(klass, VmAllocator<Entry>{&m_mm});
-    push(Value{static_cast<Obj*>(instance)}); // root instance [stack: cn, klass, inst]
+    push(Value{static_cast<Obj*>(instance)}); // root instance
 
     // c. Add function fields — each push/pop pair keeps objects rooted during
-    //    any GC that may occur inside makeString or fields.set.
-    struct FnEntry { const char* name; NativeFn fn; int arity; };
-    static const FnEntry fns[] = {
-        {"abs",   mathAbsNative,   1},
-        {"ceil",  mathCeilNative,  1},
-        {"floor", mathFloorNative, 1},
-        {"round", mathRoundNative, 1},
-        {"sqrt",  mathSqrtNative,  1},
-        {"cbrt",  mathCbrtNative,  1},
-        {"exp",   mathExpNative,   1},
-        {"log",   mathLogNative,   1},
-        {"log2",  mathLog2Native,  1},
-        {"log10", mathLog10Native, 1},
-        {"sin",   mathSinNative,   1},
-        {"cos",   mathCosNative,   1},
-        {"tan",   mathTanNative,   1},
-        {"asin",  mathAsinNative,  1},
-        {"acos",  mathAcosNative,  1},
-        {"atan",  mathAtanNative,  1},
-        {"pow",   mathPowNative,   2},
-        {"atan2", mathAtan2Native, 2},
-        {"hypot", mathHypotNative, 2},
-        {"min",   mathMinNative,   2},
-        {"max",   mathMaxNative,   2},
-    };
-
-    for (const auto& e : fns) {
+    //    any GC triggered by makeString or fields.set.
+    for (std::size_t i = 0; i < kMathFunctionCount; ++i) {
+        const auto& e = kMathFunctions[i];
         ObjNative* native = m_mm.create<ObjNative>(e.fn, e.arity);
         push(Value{static_cast<Obj*>(native)}); // root native
         ObjString* key = m_mm.makeString(e.name);
-        push(Value{static_cast<Obj*>(key)});    // root key
+        push(Value{static_cast<Obj*>(key)}); // root key
         instance->fields.set(key, Value{static_cast<Obj*>(native)});
         pop(); // key
         pop(); // native
     }
 
     // d. Add constant fields
-    struct ConstEntry { const char* name; double value; };
-    static const ConstEntry consts[] = {
-        {"pi",  M_PI},
-        {"e",   M_E},
-        {"inf", std::numeric_limits<double>::infinity()},
-        {"nan", std::numeric_limits<double>::quiet_NaN()},
-    };
-
-    for (const auto& c : consts) {
+    for (std::size_t i = 0; i < kMathConstantCount; ++i) {
+        const auto& c = kMathConstants[i];
         ObjString* key = m_mm.makeString(c.name);
         push(Value{static_cast<Obj*>(key)}); // root key
         instance->fields.set(key, from<Number>(c.value));

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -13,6 +13,7 @@
 #include <ctime>
 #include <functional>
 #include <iostream>
+#include <limits>
 #include <string>
 #include <unistd.h>
 
@@ -61,6 +62,63 @@ static Value lenNative(int /*argCount*/, Value* args) {
     auto* list = asObjList(as<Obj*>(args[0]));
     return from<Number>(static_cast<double>(list->elements.size()));
 }
+
+// ---------------------------------------------------------------------------
+// math object — native implementations
+// ---------------------------------------------------------------------------
+
+static bool mathCheckNum1(Value* args) {
+    if (!is<Number>(args[0])) {
+        nativeRuntimeError("math function argument must be a number.");
+        return false;
+    }
+    return true;
+}
+static bool mathCheckNum2(Value* args) {
+    if (!is<Number>(args[0]) || !is<Number>(args[1])) {
+        nativeRuntimeError("math function arguments must be numbers.");
+        return false;
+    }
+    return true;
+}
+
+#define MATH_UNARY(name, fn)                                                   \
+    static Value name(int /*argc*/, Value* args) {                             \
+        if (!mathCheckNum1(args)) return from<Nil>(Nil{});                     \
+        return from<Number>(fn(as<Number>(args[0])));                          \
+    }
+
+#define MATH_BINARY(name, fn)                                                  \
+    static Value name(int /*argc*/, Value* args) {                             \
+        if (!mathCheckNum2(args)) return from<Nil>(Nil{});                     \
+        return from<Number>(fn(as<Number>(args[0]), as<Number>(args[1])));     \
+    }
+
+MATH_UNARY(mathAbsNative,   std::abs)
+MATH_UNARY(mathCeilNative,  std::ceil)
+MATH_UNARY(mathFloorNative, std::floor)
+MATH_UNARY(mathRoundNative, std::round)
+MATH_UNARY(mathSqrtNative,  std::sqrt)
+MATH_UNARY(mathCbrtNative,  std::cbrt)
+MATH_UNARY(mathExpNative,   std::exp)
+MATH_UNARY(mathLogNative,   std::log)
+MATH_UNARY(mathLog2Native,  std::log2)
+MATH_UNARY(mathLog10Native, std::log10)
+MATH_UNARY(mathSinNative,   std::sin)
+MATH_UNARY(mathCosNative,   std::cos)
+MATH_UNARY(mathTanNative,   std::tan)
+MATH_UNARY(mathAsinNative,  std::asin)
+MATH_UNARY(mathAcosNative,  std::acos)
+MATH_UNARY(mathAtanNative,  std::atan)
+
+MATH_BINARY(mathPowNative,   std::pow)
+MATH_BINARY(mathAtan2Native, std::atan2)
+MATH_BINARY(mathHypotNative, std::hypot)
+MATH_BINARY(mathMinNative,   std::fmin)
+MATH_BINARY(mathMaxNative,   std::fmax)
+
+#undef MATH_UNARY
+#undef MATH_BINARY
 
 InterpretResult VM::interpret(const std::string& source) {
     ObjFunction* fn = compile(source, &m_mm);
@@ -690,6 +748,84 @@ void VM::defineNatives() {
     defineNative("input", inputNative, 0);
     defineNative("str", strNative, 1);
     defineNative("len", lenNative, 1);
+    defineMathObject();
+}
+
+void VM::defineMathObject() {
+    // a. Create the Math class (just a nominal holder for the instance)
+    ObjString* className = m_mm.makeString("Math");
+    push(Value{static_cast<Obj*>(className)}); // root className
+    ObjClass* klass = m_mm.create<ObjClass>(className, VmAllocator<Entry>{&m_mm});
+    push(Value{static_cast<Obj*>(klass)}); // root klass
+
+    // b. Create the instance
+    ObjInstance* instance =
+        m_mm.create<ObjInstance>(klass, VmAllocator<Entry>{&m_mm});
+    push(Value{static_cast<Obj*>(instance)}); // root instance [stack: cn, klass, inst]
+
+    // c. Add function fields — each push/pop pair keeps objects rooted during
+    //    any GC that may occur inside makeString or fields.set.
+    struct FnEntry { const char* name; NativeFn fn; int arity; };
+    static const FnEntry fns[] = {
+        {"abs",   mathAbsNative,   1},
+        {"ceil",  mathCeilNative,  1},
+        {"floor", mathFloorNative, 1},
+        {"round", mathRoundNative, 1},
+        {"sqrt",  mathSqrtNative,  1},
+        {"cbrt",  mathCbrtNative,  1},
+        {"exp",   mathExpNative,   1},
+        {"log",   mathLogNative,   1},
+        {"log2",  mathLog2Native,  1},
+        {"log10", mathLog10Native, 1},
+        {"sin",   mathSinNative,   1},
+        {"cos",   mathCosNative,   1},
+        {"tan",   mathTanNative,   1},
+        {"asin",  mathAsinNative,  1},
+        {"acos",  mathAcosNative,  1},
+        {"atan",  mathAtanNative,  1},
+        {"pow",   mathPowNative,   2},
+        {"atan2", mathAtan2Native, 2},
+        {"hypot", mathHypotNative, 2},
+        {"min",   mathMinNative,   2},
+        {"max",   mathMaxNative,   2},
+    };
+
+    for (const auto& e : fns) {
+        ObjNative* native = m_mm.create<ObjNative>(e.fn, e.arity);
+        push(Value{static_cast<Obj*>(native)}); // root native
+        ObjString* key = m_mm.makeString(e.name);
+        push(Value{static_cast<Obj*>(key)});    // root key
+        instance->fields.set(key, Value{static_cast<Obj*>(native)});
+        pop(); // key
+        pop(); // native
+    }
+
+    // d. Add constant fields
+    struct ConstEntry { const char* name; double value; };
+    static const ConstEntry consts[] = {
+        {"pi",  M_PI},
+        {"e",   M_E},
+        {"inf", std::numeric_limits<double>::infinity()},
+        {"nan", std::numeric_limits<double>::quiet_NaN()},
+    };
+
+    for (const auto& c : consts) {
+        ObjString* key = m_mm.makeString(c.name);
+        push(Value{static_cast<Obj*>(key)}); // root key
+        instance->fields.set(key, from<Number>(c.value));
+        pop(); // key
+    }
+
+    // e-f. Register instance as global "math"
+    ObjString* globalKey = m_mm.makeString("math");
+    push(Value{static_cast<Obj*>(globalKey)}); // root key
+    m_globals.set(globalKey, Value{static_cast<Obj*>(instance)});
+    pop(); // globalKey
+
+    // g. Pop instance, klass, className
+    pop(); // instance
+    pop(); // klass
+    pop(); // className
 }
 
 void VM::runtimeError(const char* format, ...) {

--- a/src/vm.h
+++ b/src/vm.h
@@ -54,6 +54,7 @@ class VM {
     bool bindMethod(ObjClass* klass, ObjString* name);
     void defineNative(const char* name, NativeFn fn, int arity);
     void defineNatives();
+    void defineMathObject();
     ObjUpvalue* captureUpvalue(Value* local);
     void closeUpvalues(Value* last);
     void runtimeError(const char* format, ...);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,7 @@ set(ALLOC_SRCS
 
 set(FULL_SRCS
     ${PROJECT_SOURCE_DIR}/src/vm.cpp
+    ${PROJECT_SOURCE_DIR}/src/math.cpp
     ${PROJECT_SOURCE_DIR}/src/compiler.cpp
     ${PROJECT_SOURCE_DIR}/src/parser.cpp
     ${PROJECT_SOURCE_DIR}/src/chunk.cpp


### PR DESCRIPTION
## Summary

- Adds a global `math` object (an `ObjInstance`) whose fields are `ObjNative` values, enabling `math.sqrt(x)`, `math.pow(x, y)`, `math.pi`, etc.
- 21 functions: `abs`, `ceil`, `floor`, `round`, `sqrt`, `cbrt`, `exp`, `log`, `log2`, `log10`, `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `pow`, `atan2`, `hypot`, `min`, `max`
- 4 constants: `pi`, `e`, `inf`, `nan`
- No new opcodes — `GET_PROPERTY` + `CALL` already dispatches `ObjNative` fields correctly
- GC-safe: follows the existing `defineNative()` push-before-alloc discipline

## Test plan

- [x] All 15 existing tests pass (`ctest`)
- [x] New `examples/math_demo.lox` runs and produces correct output (FileCheck annotations included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)