### PR TITLE
docs: add math stdlib example programs

### DIFF
--- a/examples/newton_sqrt.lox
+++ b/examples/newton_sqrt.lox
@@ -1,0 +1,49 @@
+// newton_sqrt.lox — Newton's method (Heron's method) for square roots.
+//
+// Demonstrates: math.abs, math.sqrt (for verification)
+//
+// Newton's method for sqrt(n): starting from an initial guess x,
+// repeatedly apply x = (x + n/x) / 2 until |x^2 - n| < epsilon.
+
+fun sqrtNewton(n) {
+    var x = 1;          // initial guess
+    var eps = 0.000001; // convergence threshold
+    while (math.abs(x * x - n) > eps) {
+        x = (x + n / x) / 2;
+    }
+    return x;
+}
+
+// CHECK: === Newton convergence for sqrt(2) ===
+print "=== Newton convergence for sqrt(2) ===";
+var x = 1;
+var step = 0;
+while (step < 5) {
+    x = (x + 2 / x) / 2;
+    print "  step " + str(step + 1) + ": x = " + str(x);
+    step = step + 1;
+}
+// CHECK:   step 1: x = 1.5
+// CHECK:   step 2: x = 1.41667
+// CHECK:   step 3: x = 1.41422
+// CHECK:   step 4: x = 1.41421
+// CHECK:   step 5: x = 1.41421
+
+// CHECK: === Comparison with math.sqrt ===
+print "";
+print "=== Comparison with math.sqrt ===";
+var targets = [ 2, 9, 25, 144, 10000 ];
+var i = 0;
+while (i < 5) {
+    var n = targets[i];
+    var approx = sqrtNewton(n);
+    var exact = math.sqrt(n);
+    print "  sqrt(" + str(n) + "):" + "  newton=" + str(approx) +
+        "  exact=" + str(exact);
+    i = i + 1;
+}
+// CHECK:   sqrt(2):  newton=1.41421  exact=1.41421
+// CHECK:   sqrt(9):  newton=3  exact=3
+// CHECK:   sqrt(25):  newton=5  exact=5
+// CHECK:   sqrt(144):  newton=12  exact=12
+// CHECK:   sqrt(10000):  newton=100  exact=100

--- a/examples/polar.lox
+++ b/examples/polar.lox
@@ -1,0 +1,59 @@
+// polar.lox — Cartesian ↔ polar coordinate conversion and unit circle table.
+//
+// Demonstrates: math.sin, math.cos, math.tan, math.atan2, math.hypot, math.pi
+
+fun toDegrees(radians) { return radians * 180 / math.pi; }
+
+fun toRadians(degrees) { return degrees * math.pi / 180; }
+
+// Print (x, y) in polar form.
+fun cartToPolar(x, y) {
+    var r = math.hypot(x, y);
+    var theta = toDegrees(math.atan2(y, x));
+    print "  (" + str(x) + ", " + str(y) + ")" + " -> r=" + str(r) +
+        ", theta=" + str(theta) + " deg";
+}
+
+// Print polar (r, degrees) in Cartesian form.
+fun polarToCart(r, degrees) {
+    var x = r * math.cos(toRadians(degrees));
+    var y = r * math.sin(toRadians(degrees));
+    print "  r=" + str(r) + ", theta=" + str(degrees) + " deg" + " -> (" +
+        str(x) + ", " + str(y) + ")";
+}
+
+// CHECK: === Cartesian to Polar ===
+print "=== Cartesian to Polar ===";
+// CHECK:   (3, 4) -> r=5, theta=53.1301 deg
+cartToPolar(3, 4);
+// CHECK:   (1, 0) -> r=1, theta=0 deg
+cartToPolar(1, 0);
+// CHECK:   (0, 1) -> r=1, theta=90 deg
+cartToPolar(0, 1);
+// CHECK:   (-1, 0) -> r=1, theta=180 deg
+cartToPolar(-1, 0);
+
+// CHECK: === Polar to Cartesian ===
+print "";
+print "=== Polar to Cartesian ===";
+// CHECK:   r=5, theta=53.1301 deg -> (3, 4)
+polarToCart(5, 53.1301023541559);
+// CHECK:   r=10, theta=45 deg -> (7.07107, 7.07107)
+polarToCart(10, 45);
+
+// CHECK: === Unit Circle (sin, cos, tan) ===
+print "";
+print "=== Unit Circle (sin, cos, tan) ===";
+var angles = [ 0, 30, 45, 60 ];
+var i = 0;
+while (i < 4) {
+    var deg = angles[i];
+    var rad = toRadians(deg);
+    print "  " + str(deg) + " deg:" + "  sin=" + str(math.sin(rad)) +
+        "  cos=" + str(math.cos(rad)) + "  tan=" + str(math.tan(rad));
+    i = i + 1;
+}
+// CHECK:   0 deg:  sin=0  cos=1  tan=0
+// CHECK:   30 deg:  sin=0.5  cos=0.866025  tan=0.57735
+// CHECK:   45 deg:  sin=0.707107  cos=0.707107  tan=1
+// CHECK:   60 deg:  sin=0.866025  cos=0.5  tan=1.73205

--- a/examples/shapes.lox
+++ b/examples/shapes.lox
@@ -1,6 +1,7 @@
 // shapes.lox — Class hierarchy with polymorphic area().
 //
-// Demonstrates: inheritance, super, dynamic dispatch, method overriding.
+// Demonstrates: inheritance, super, dynamic dispatch, method overriding,
+// math.pi
 
 class Shape {
     name() { return "Shape"; }
@@ -8,36 +9,36 @@ class Shape {
     perimeter() { return 0; }
 
     describe() {
-        print this.name()
-            + ": area=" + str(this.area())
-            + ", perimeter=" + str(this.perimeter());
+        print this.name() + ": area=" + str(this.area()) +
+            ", perimeter=" + str(this.perimeter());
     }
 }
 
-class Circle < Shape {
+    class Circle < Shape {
     init(radius) { this.radius = radius; }
     name() { return "Circle(r=" + str(this.radius) + ")"; }
-    // pi approximation — math.pi is a future milestone
-    area() { return 3.14159 * this.radius * this.radius; }
-    perimeter() { return 2 * 3.14159 * this.radius; }
+    area() { return math.pi * this.radius * this.radius; }
+    perimeter() { return 2 * math.pi * this.radius; }
 }
 
-class Rectangle < Shape {
+    class Rectangle < Shape {
     init(width, height) {
         this.width = width;
         this.height = height;
     }
-    name() { return "Rectangle(" + str(this.width) + "x" + str(this.height) + ")"; }
+    name() {
+        return "Rectangle(" + str(this.width) + "x" + str(this.height) + ")";
+    }
     area() { return this.width * this.height; }
     perimeter() { return 2 * (this.width + this.height); }
 }
 
-class Square < Rectangle {
+    class Square < Rectangle {
     init(side) { super.init(side, side); }
     name() { return "Square(" + str(this.width) + ")"; }
 }
 
-class Triangle < Shape {
+    class Triangle < Shape {
     init(base, height, a, b, c) {
         this.base = base;
         this.height = height;
@@ -45,7 +46,9 @@ class Triangle < Shape {
         this.b = b;
         this.c = c;
     }
-    name() { return "Triangle(b=" + str(this.base) + ", h=" + str(this.height) + ")"; }
+    name() {
+        return "Triangle(b=" + str(this.base) + ", h=" + str(this.height) + ")";
+    }
     area() { return 0.5 * this.base * this.height; }
     perimeter() { return this.a + this.b + this.c; }
 }
@@ -53,19 +56,14 @@ class Triangle < Shape {
 // CHECK: === Shape Hierarchy ===
 print "=== Shape Hierarchy ===";
 
-var shapes = [
-    Circle(5),
-    Rectangle(4, 6),
-    Square(3),
-    Triangle(6, 4, 5, 5, 6)
-];
+var shapes = [ Circle(5), Rectangle(4, 6), Square(3), Triangle(6, 4, 5, 5, 6) ];
 
 var i = 0;
 while (i < 4) {
     shapes[i].describe();
     i = i + 1;
 }
-// CHECK: Circle(r=5): area=78.5397, perimeter=31.4159
+// CHECK: Circle(r=5): area=78.5398, perimeter=31.4159
 // CHECK: Rectangle(4x6): area=24, perimeter=20
 // CHECK: Square(3): area=9, perimeter=12
 // CHECK: Triangle(b=6, h=4): area=12, perimeter=16

--- a/examples/stats.lox
+++ b/examples/stats.lox
@@ -1,0 +1,86 @@
+// stats.lox — Descriptive statistics: mean, variance, standard deviation.
+//
+// Demonstrates: math.sqrt, math.min, math.max, math.abs
+
+fun mean(data, n) {
+    var sum = 0;
+    var i = 0;
+    while (i < n) {
+        sum = sum + data[i];
+        i = i + 1;
+    }
+    return sum / n;
+}
+
+fun variance(data, n, avg) {
+    var sum = 0;
+    var i = 0;
+    while (i < n) {
+        var diff = data[i] - avg;
+        sum = sum + diff * diff;
+        i = i + 1;
+    }
+    return sum / n;
+}
+
+fun listMin(data, n) {
+    var m = data[0];
+    var i = 1;
+    while (i < n) {
+        m = math.min(m, data[i]);
+        i = i + 1;
+    }
+    return m;
+}
+
+fun listMax(data, n) {
+    var m = data[0];
+    var i = 1;
+    while (i < n) {
+        m = math.max(m, data[i]);
+        i = i + 1;
+    }
+    return m;
+}
+
+fun summarize(data, n) {
+    var avg = mean(data, n);
+    var varr = variance(data, n, avg);
+    var stddev = math.sqrt(varr);
+    var lo = listMin(data, n);
+    var hi = listMax(data, n);
+    print "  n        = " + str(n);
+    print "  mean     = " + str(avg);
+    print "  variance = " + str(varr);
+    print "  std dev  = " + str(stddev);
+    print "  min      = " + str(lo);
+    print "  max      = " + str(hi);
+    print "  range    = " + str(hi - lo);
+}
+
+// Data set 1: perfect bell — mean=5, stddev=2
+var data1 = [ 2, 4, 4, 4, 5, 5, 7, 9 ];
+// CHECK: === data1 ===
+print "=== data1 ===";
+// CHECK:   n        = 8
+// CHECK:   mean     = 5
+// CHECK:   variance = 4
+// CHECK:   std dev  = 2
+// CHECK:   min      = 2
+// CHECK:   max      = 9
+// CHECK:   range    = 7
+summarize(data1, 8);
+
+// Data set 2: uniform [1..5]
+print "";
+var data2 = [ 1, 2, 3, 4, 5 ];
+// CHECK: === data2 ===
+print "=== data2 ===";
+// CHECK:   n        = 5
+// CHECK:   mean     = 3
+// CHECK:   variance = 2
+// CHECK:   std dev  = 1.41421
+// CHECK:   min      = 1
+// CHECK:   max      = 5
+// CHECK:   range    = 4
+summarize(data2, 5);


### PR DESCRIPTION
## Summary

Three new example programs showcasing the `math` global object added in #47:

- **`polar.lox`** — Cartesian ↔ polar coordinate conversion using `math.sin`, `math.cos`, `math.tan`, `math.atan2`, `math.hypot`, `math.pi`
- **`stats.lox`** — Descriptive statistics (mean, population variance, stddev, min/max/range) using `math.sqrt`, `math.min`, `math.max`
- **`newton_sqrt.lox`** — Newton/Heron's method for square roots, showing convergence in 5 steps and comparing against `math.sqrt`

Also updates `shapes.lox` to use `math.pi` instead of the hardcoded approximation `3.14159`.

## Test plan

- [x] All 15 existing tests pass
- [x] All four `.lox` files produce output matching their FileCheck annotations
- [x] `clang-format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)