### PR TITLE
feat: add file I/O API

### DIFF
--- a/src/function.h
+++ b/src/function.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdio>
+
 #include "chunk.h"
 #include "object.h"
 #include "table.h"
@@ -116,4 +118,25 @@ inline bool isObjList(Obj* o) { return isObjType(o, ObjType::LIST); }
 inline ObjList* asObjList(Obj* o) { return static_cast<ObjList*>(o); }
 inline bool isList(const Value& v) {
     return is<Obj*>(v) && as<Obj*>(v)->type == ObjType::LIST;
+}
+
+struct ObjFile : public Obj {
+    ObjClass* klass;       // shared s_fileClass; GC-tracked
+    FILE* handle{nullptr}; // null when closed
+    bool readable{false};
+    bool writable{false};
+
+    explicit ObjFile(ObjClass* k) : Obj(ObjType::FILE), klass(k) {}
+    ~ObjFile() override {
+        if (handle) {
+            std::fclose(handle);
+            handle = nullptr;
+        }
+    }
+};
+
+inline bool isObjFile(Obj* o) { return isObjType(o, ObjType::FILE); }
+inline ObjFile* asObjFile(Obj* o) { return static_cast<ObjFile*>(o); }
+inline bool isFile(const Value& v) {
+    return is<Obj*>(v) && as<Obj*>(v)->type == ObjType::FILE;
 }

--- a/src/function.h
+++ b/src/function.h
@@ -127,6 +127,10 @@ struct ObjFile : public Obj {
     bool writable{false};
 
     explicit ObjFile(ObjClass* k) : Obj(ObjType::FILE), klass(k) {}
+    // TODO(loctx): Do NOT rely on this destructor to close file handles.
+    // GC timing is non-deterministic; an open file may not be collected until
+    // program exit (or never, if the heap is not exhausted). Always call
+    // f.close() explicitly.
     ~ObjFile() override {
         if (handle) {
             std::fclose(handle);

--- a/src/memory_manager.cpp
+++ b/src/memory_manager.cpp
@@ -28,6 +28,8 @@ static const char* objTypeName(ObjType type) {
         return "bound_method";
     case ObjType::LIST:
         return "list";
+    case ObjType::FILE:
+        return "file";
     }
     return "?";
 }
@@ -185,6 +187,9 @@ void MemoryManager::traceObject(Obj* obj) {
             markValue(v);
         break;
     }
+    case ObjType::FILE:
+        markObject(static_cast<ObjFile*>(obj)->klass);
+        break;
     }
 }
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -49,6 +49,8 @@ std::string stringifyObj(Obj* obj) {
                std::string(fn->name->chars.data(), fn->name->chars.size()) +
                ">";
     }
+    case ObjType::FILE:
+        return "<file>";
     case ObjType::LIST: {
         auto* list = static_cast<ObjList*>(obj);
         std::string result = "[";

--- a/src/object.h
+++ b/src/object.h
@@ -15,7 +15,8 @@ enum class ObjType : uint8_t {
     CLASS,
     INSTANCE,
     BOUND_METHOD,
-    LIST
+    LIST,
+    FILE
 };
 
 inline uint32_t hashString(std::string_view s) {

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -9,10 +9,12 @@
 
 #include "math.h"
 
+#include <cerrno>
 #include <cmath>
 #include <cstddef>
 #include <cstdio>
 #include <cstdarg>
+#include <cstring>
 #include <ctime>
 #include <functional>
 #include <iostream>
@@ -69,7 +71,196 @@ static Value lenNative(int /*argCount*/, Value* args) {
     return from<Nil>(Nil{});
 }
 
+// ---------------------------------------------------------------------------
+// File API — ObjFile native methods and open() factory
+// ---------------------------------------------------------------------------
+
+static ObjClass* s_fileClass = nullptr;
+
+// Validate that args[-1] is an open ObjFile. Returns nullptr and sets a
+// runtime error if the file is closed.
+static ObjFile* checkFile(Value* args, const char* method) {
+    ObjFile* file = asObjFile(as<Obj*>(args[-1]));
+    if (!file->handle) {
+        std::string msg = "Cannot call '";
+        msg += method;
+        msg += "' on a closed file.";
+        nativeRuntimeError(msg.c_str());
+        return nullptr;
+    }
+    return file;
+}
+
+static Value fileReadNative(int /*argc*/, Value* args) {
+    ObjFile* file = checkFile(args, "read");
+    if (!file)
+        return from<Nil>(Nil{});
+    if (!file->readable) {
+        nativeRuntimeError("File is not open for reading.");
+        return from<Nil>(Nil{});
+    }
+    std::string buf;
+    char chunk[4096];
+    while (std::fgets(chunk, sizeof(chunk), file->handle))
+        buf += chunk;
+    return Value{static_cast<Obj*>(s_currentMM->makeString(std::move(buf)))};
+}
+
+static Value fileReadlineNative(int /*argc*/, Value* args) {
+    ObjFile* file = checkFile(args, "readline");
+    if (!file)
+        return from<Nil>(Nil{});
+    if (!file->readable) {
+        nativeRuntimeError("File is not open for reading.");
+        return from<Nil>(Nil{});
+    }
+    std::string line;
+    char chunk[4096];
+    bool got = false;
+    while (std::fgets(chunk, sizeof(chunk), file->handle)) {
+        got = true;
+        line += chunk;
+        if (!line.empty() && line.back() == '\n') {
+            line.pop_back();
+            break;
+        }
+    }
+    if (!got)
+        return from<Nil>(Nil{});
+    return Value{static_cast<Obj*>(s_currentMM->makeString(std::move(line)))};
+}
+
+static Value fileReadlinesNative(int /*argc*/, Value* args) {
+    ObjFile* file = checkFile(args, "readlines");
+    if (!file)
+        return from<Nil>(Nil{});
+    if (!file->readable) {
+        nativeRuntimeError("File is not open for reading.");
+        return from<Nil>(Nil{});
+    }
+    ObjList* list =
+        s_currentMM->create<ObjList>(VmAllocator<Value>{s_currentMM});
+    s_currentMM->pushTempRoot(list);
+    char chunk[4096];
+    std::string line;
+    auto flush = [&]() {
+        ObjString* s = s_currentMM->makeString(line);
+        // Protect s across push_back, which can GC on vector resize.
+        s_currentMM->pushTempRoot(s);
+        list->elements.push_back(Value{static_cast<Obj*>(s)});
+        s_currentMM->popTempRoot();
+        line.clear();
+    };
+    while (std::fgets(chunk, sizeof(chunk), file->handle)) {
+        line += chunk;
+        if (!line.empty() && line.back() == '\n') {
+            line.pop_back();
+            flush();
+        }
+    }
+    if (!line.empty())
+        flush(); // trailing line with no newline
+    s_currentMM->popTempRoot();
+    return Value{static_cast<Obj*>(list)};
+}
+
+static Value fileWriteNative(int /*argc*/, Value* args) {
+    ObjFile* file = checkFile(args, "write");
+    if (!file)
+        return from<Nil>(Nil{});
+    if (!file->writable) {
+        nativeRuntimeError("File is not open for writing.");
+        return from<Nil>(Nil{});
+    }
+    if (!isString(args[0])) {
+        nativeRuntimeError("'write' argument must be a string.");
+        return from<Nil>(Nil{});
+    }
+    auto* s = asObjString(as<Obj*>(args[0]));
+    std::fwrite(s->chars.data(), 1, s->chars.size(), file->handle);
+    return from<Nil>(Nil{});
+}
+
+static Value fileWritelineNative(int /*argc*/, Value* args) {
+    ObjFile* file = checkFile(args, "writeline");
+    if (!file)
+        return from<Nil>(Nil{});
+    if (!file->writable) {
+        nativeRuntimeError("File is not open for writing.");
+        return from<Nil>(Nil{});
+    }
+    if (!isString(args[0])) {
+        nativeRuntimeError("'writeline' argument must be a string.");
+        return from<Nil>(Nil{});
+    }
+    auto* s = asObjString(as<Obj*>(args[0]));
+    std::fwrite(s->chars.data(), 1, s->chars.size(), file->handle);
+    std::fputc('\n', file->handle);
+    return from<Nil>(Nil{});
+}
+
+static Value fileCloseNative(int /*argc*/, Value* args) {
+    // Idempotent — no error if already closed.
+    ObjFile* file = asObjFile(as<Obj*>(args[-1]));
+    if (file->handle) {
+        std::fclose(file->handle);
+        file->handle = nullptr;
+    }
+    return from<Nil>(Nil{});
+}
+
+static Value openNative(int /*argc*/, Value* args) {
+    if (!isString(args[0]) || !isString(args[1])) {
+        nativeRuntimeError("open() requires string path and mode.");
+        return from<Nil>(Nil{});
+    }
+    auto* pathStr = asObjString(as<Obj*>(args[0]));
+    auto* modeStr = asObjString(as<Obj*>(args[1]));
+    std::string modeS(modeStr->chars.data(), modeStr->chars.size());
+
+    bool readable = false, writable = false;
+    const char* cmode = nullptr;
+    if (modeS == "r") {
+        readable = true;
+        cmode = "r";
+    } else if (modeS == "w") {
+        writable = true;
+        cmode = "w";
+    } else if (modeS == "a") {
+        writable = true;
+        cmode = "a";
+    } else if (modeS == "r+") {
+        readable = writable = true;
+        cmode = "r+";
+    } else {
+        nativeRuntimeError(
+            "open(): invalid mode. Expected \"r\", \"w\", \"a\", or \"r+\".");
+        return from<Nil>(Nil{});
+    }
+    std::string pathS(pathStr->chars.data(), pathStr->chars.size());
+    FILE* fp = std::fopen(pathS.c_str(), cmode);
+    if (!fp) {
+        std::string msg = "open(): cannot open '";
+        msg += pathS;
+        msg += "': ";
+        msg += std::strerror(errno);
+        nativeRuntimeError(msg.c_str());
+        return from<Nil>(Nil{});
+    }
+    ObjFile* file = s_currentMM->create<ObjFile>(s_fileClass);
+    s_currentMM->pushTempRoot(file);
+    file->handle = fp;
+    file->readable = readable;
+    file->writable = writable;
+    s_currentMM->popTempRoot();
+    return Value{static_cast<Obj*>(file)};
+}
+
 InterpretResult VM::interpret(const std::string& source) {
+    // Guard against a dangling s_fileClass from a prior VM instance. GC can
+    // fire inside compile(), and markRoots() must not dereference a pointer
+    // that was freed when the previous VM's MemoryManager was destroyed.
+    s_fileClass = nullptr;
     ObjFunction* fn = compile(source, &m_mm);
     if (fn == nullptr) {
         return InterpretResult::COMPILE_ERROR;
@@ -391,6 +582,18 @@ InterpretResult VM::run() {
             break;
         }
         case Op::GET_PROPERTY: {
+            if (isFile(peek(0))) {
+                ObjString* name = asObjString(readConstant());
+                Value method;
+                if (!s_fileClass->methods.get(name, method)) {
+                    runtimeError("Undefined property '%s' on file.",
+                                 name->chars.c_str());
+                    return InterpretResult::RUNTIME_ERROR;
+                }
+                pop();        // file
+                push(method); // ObjNative (unbound)
+                break;
+            }
             if (!isInstance(peek(0))) {
                 runtimeError("Only instances have properties.");
                 return InterpretResult::RUNTIME_ERROR;
@@ -461,9 +664,15 @@ InterpretResult VM::run() {
                                  name->chars.c_str());
                     return InterpretResult::RUNTIME_ERROR;
                 }
-                if (!call(asObjClosure(as<Obj*>(method)), argCount))
-                    return InterpretResult::RUNTIME_ERROR;
-                frame = &m_frames[m_frameCount - 1];
+                Obj* methodObj = as<Obj*>(method);
+                if (isObjNative(methodObj)) {
+                    if (!callNative(asObjNative(methodObj), argCount))
+                        return InterpretResult::RUNTIME_ERROR;
+                } else {
+                    if (!call(asObjClosure(methodObj), argCount))
+                        return InterpretResult::RUNTIME_ERROR;
+                    frame = &m_frames[m_frameCount - 1];
+                }
             } else if (isList(receiver)) {
                 ObjList* list = asObjList(as<Obj*>(receiver));
                 if (name->chars == "append") {
@@ -497,8 +706,17 @@ InterpretResult VM::run() {
                                  name->chars.c_str());
                     return InterpretResult::RUNTIME_ERROR;
                 }
+            } else if (isFile(receiver)) {
+                Value method;
+                if (!s_fileClass->methods.get(name, method)) {
+                    runtimeError("Undefined method '%s' on file.",
+                                 name->chars.c_str());
+                    return InterpretResult::RUNTIME_ERROR;
+                }
+                if (!callNative(asObjNative(as<Obj*>(method)), argCount))
+                    return InterpretResult::RUNTIME_ERROR;
             } else {
-                runtimeError("Only instances have methods.");
+                runtimeError("Only instances and files have methods.");
                 return InterpretResult::RUNTIME_ERROR;
             }
             break;
@@ -755,6 +973,38 @@ void VM::defineNatives() {
     defineNative("str", strNative, 1);
     defineNative("len", lenNative, 1);
     defineMathObject();
+    defineFileAPI();
+}
+
+void VM::defineFileAPI() {
+    ObjString* className = m_mm.makeString("File");
+    push(Value{static_cast<Obj*>(className)});
+    ObjClass* klass =
+        m_mm.create<ObjClass>(className, VmAllocator<Entry>{&m_mm});
+    push(Value{static_cast<Obj*>(klass)});
+
+    auto addMethod = [&](const char* n, NativeFn fn, int arity) {
+        ObjNative* native = m_mm.create<ObjNative>(fn, arity);
+        push(Value{static_cast<Obj*>(native)});
+        ObjString* key = m_mm.makeString(n);
+        push(Value{static_cast<Obj*>(key)});
+        klass->methods.set(key, Value{static_cast<Obj*>(native)});
+        pop();
+        pop(); // key, native
+    };
+
+    addMethod("read", fileReadNative, 0);
+    addMethod("readline", fileReadlineNative, 0);
+    addMethod("readlines", fileReadlinesNative, 0);
+    addMethod("write", fileWriteNative, 1);
+    addMethod("writeline", fileWritelineNative, 1);
+    addMethod("close", fileCloseNative, 0);
+
+    s_fileClass = klass;
+    pop();
+    pop(); // klass, className
+
+    defineNative("open", openNative, 2);
 }
 
 void VM::defineMathObject() {
@@ -841,6 +1091,8 @@ void VM::markRoots() {
         m_mm.markObject(key);
         m_mm.markValue(val);
     });
+    if (s_fileClass)
+        m_mm.markObject(s_fileClass);
 }
 
 void VM::resetStack() {

--- a/src/vm.h
+++ b/src/vm.h
@@ -55,6 +55,7 @@ class VM {
     void defineNative(const char* name, NativeFn fn, int arity);
     void defineNatives();
     void defineMathObject();
+    void defineFileAPI();
     ObjUpvalue* captureUpvalue(Value* local);
     void closeUpvalues(Value* last);
     void runtimeError(const char* format, ...);


### PR DESCRIPTION
## Summary

- Adds `ObjFile` as a first-class Lox++ object type with a shared `fileClass` holding native methods
- Exposes `open(path, mode)` global factory (modes: `"r"`, `"w"`, `"a"`, `"r+"`)
- File methods: `read()`, `readline()`, `readlines()`, `write(str)`, `writeline(str)`, `close()`
- Generalises `Op::INVOKE` to dispatch `ObjNative` methods from any Lox class (not just closures), benefiting future native types

## Design notes

`ObjFile` follows the same pattern as `ObjList`: methods live in a shared `s_fileClass` populated at VM startup via `defineFileAPI()`. Method dispatch reuses the existing INVOKE/GET_PROPERTY paths with a small file-specific branch, keeping the VM switch maintainable.

`~ObjFile()` closes the underlying `FILE*` via virtual dispatch from `sweep()`, so files are always closed when collected even without an explicit `f.close()`.

`s_fileClass` is a module-level static cleared at the top of `VM::interpret()` to prevent dangling pointer dereference when GC fires during compilation in a subsequent VM instance (caught by stress-GC tests).

## Test plan

- [ ] `f.read()` returns full file contents as a string
- [ ] `f.readline()` returns lines one at a time; returns `nil` on EOF
- [ ] `f.readlines()` returns a `List` of all lines
- [ ] `f.write(str)` / `f.writeline(str)` write to file; verify with read-back
- [ ] `f.close()` is idempotent (calling twice does not crash)
- [ ] Runtime error on bad mode (`open("x", "z")`)
- [ ] Runtime error on file-not-found in read mode
- [ ] Runtime error calling a method on a closed file
- [ ] All 15 existing tests pass (`ctest --test-dir build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)