### PR TITLE
feat: NaN-tagged Value representation behind LOXPP_NAN_TAGGING flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if(NOT _git_config_result EQUAL 0)
     message(WARNING "Failed to set core.hooksPath — git hooks will not run automatically.")
 endif()
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -24,7 +24,6 @@ add_executable(loxpp
     src/main.cpp
     src/chunk.cpp
     src/debug.cpp
-    src/value.cpp
     src/object.cpp
     src/table.cpp
     src/memory_manager.cpp
@@ -65,6 +64,14 @@ option(LOXPP_STRESS_GC
 if(LOXPP_STRESS_GC)
     target_compile_definitions(loxpp PRIVATE LOXPP_STRESS_GC)
 endif()
+option(LOXPP_NAN_TAGGING "Use NaN-tagged Value representation (8 bytes vs 16)" OFF)
+if(LOXPP_NAN_TAGGING)
+    set(LOXPP_VALUE_SRC ${PROJECT_SOURCE_DIR}/src/value_nan.cpp)
+    target_compile_definitions(loxpp PRIVATE LOXPP_NAN_TAGGING)
+else()
+    set(LOXPP_VALUE_SRC ${PROJECT_SOURCE_DIR}/src/value.cpp)
+endif()
+target_sources(loxpp PRIVATE ${LOXPP_VALUE_SRC})
 
 # Readline support for the REPL.
 find_library(READLINE_LIB readline)

--- a/src/value.h
+++ b/src/value.h
@@ -4,9 +4,130 @@
 
 #include <array>
 #include <cstdint>
-#include <variant>
 
 using Number = double;
+
+#ifdef LOXPP_NAN_TAGGING
+
+#include <bit>
+#include <variant> // for std::monostate (Nil)
+
+// ---- NaN-boxing constants ------------------------------------------------
+// A quiet NaN has exponent all-ones (bits 62:52) and quiet bit (bit 51) set.
+// We additionally require bit 50, giving QNAN = 0x7FFC000000000000. This
+// ensures that CPU-generated arithmetic NaN (0x7FF8000000000000) is NOT
+// caught by our sentinel test and still passes as a Number value.
+namespace detail {
+static constexpr uint64_t QNAN = 0x7FFC000000000000ULL;
+static constexpr uint64_t SIGN_BIT = 0x8000000000000000ULL;
+static constexpr uint64_t OBJ_TAG = QNAN | SIGN_BIT; // 0xFFFC000000000000
+
+static constexpr uint64_t VAL_NIL = QNAN | 0x01ULL;
+static constexpr uint64_t VAL_FALSE = QNAN | 0x02ULL;
+static constexpr uint64_t VAL_TRUE = QNAN | 0x03ULL;
+} // namespace detail
+
+using Nil = std::monostate;
+
+// NaN-tagged Value: all types encoded in a single 8-byte word.
+//
+// Constructors for double and bool are intentionally non-explicit so that
+// the existing BINARY_OP macro in vm.cpp (`push(as<valueType>(a op b))`)
+// compiles without change — `bool` produced by a comparison implicitly
+// converts to Value via the bool constructor, exactly as it did with the
+// old std::variant (which was also implicitly constructible from bool).
+struct Value {
+    uint64_t bits;
+
+    Value() noexcept : bits(detail::VAL_NIL) {}
+    Value(double d) noexcept : bits(std::bit_cast<uint64_t>(d)) {}
+    Value(bool b) noexcept : bits(b ? detail::VAL_TRUE : detail::VAL_FALSE) {}
+    Value(std::monostate) noexcept : bits(detail::VAL_NIL) {}
+    explicit Value(Obj* p) noexcept
+        : bits(detail::OBJ_TAG | reinterpret_cast<uint64_t>(p)) {}
+
+    static_assert(sizeof(double) == 8 && sizeof(uint64_t) == 8,
+                  "Platform must have 64-bit doubles and 64-bit pointers");
+};
+
+static_assert(sizeof(Value) == 8, "NaN-boxed Value must be 8 bytes");
+
+// ---- is<T> ---------------------------------------------------------------
+template <typename T>
+bool is(const Value& v);
+
+template <>
+inline bool is<Number>(const Value& v) {
+    return (v.bits & detail::QNAN) != detail::QNAN;
+}
+
+template <>
+inline bool is<bool>(const Value& v) {
+    return v.bits == detail::VAL_TRUE || v.bits == detail::VAL_FALSE;
+}
+
+template <>
+inline bool is<Nil>(const Value& v) {
+    return v.bits == detail::VAL_NIL;
+}
+
+template <>
+inline bool is<Obj*>(const Value& v) {
+    return (v.bits & detail::OBJ_TAG) == detail::OBJ_TAG;
+}
+
+// ---- as<T> ---------------------------------------------------------------
+template <typename T>
+T as(const Value& v);
+
+template <>
+inline Number as<Number>(const Value& v) {
+    return std::bit_cast<double>(v.bits);
+}
+
+template <>
+inline bool as<bool>(const Value& v) {
+    return v.bits == detail::VAL_TRUE;
+}
+
+template <>
+inline Nil as<Nil>(const Value&) {
+    return {};
+}
+
+template <>
+inline Obj* as<Obj*>(const Value& v) {
+    return reinterpret_cast<Obj*>(v.bits & ~detail::OBJ_TAG);
+}
+
+// ---- from<T> -------------------------------------------------------------
+template <typename T>
+Value from(const T& val);
+
+template <>
+inline Value from<Number>(const Number& val) {
+    return Value{val};
+}
+
+template <>
+inline Value from<bool>(const bool& val) {
+    return Value{val};
+}
+
+template <>
+inline Value from<Nil>(const Nil&) {
+    return Value{std::monostate{}};
+}
+
+template <>
+inline Value from<Obj*>(Obj* const& val) {
+    return Value{val};
+}
+
+#else // !LOXPP_NAN_TAGGING — original std::variant implementation
+
+#include <variant>
+
 using Nil = std::monostate;
 using Value = std::variant<bool, Number, Nil, Obj*>;
 
@@ -27,6 +148,9 @@ Value from(const T& val) {
     return Value(val);
 }
 
+#endif // LOXPP_NAN_TAGGING
+
+// ---- inline helpers (same in both paths, built on is<>/as<>) -------------
 inline bool isObj(const Value& v) { return is<Obj*>(v); }
 inline bool isString(const Value& v) {
     return is<Obj*>(v) && as<Obj*>(v)->type == ObjType::STRING;

--- a/src/value_nan.cpp
+++ b/src/value_nan.cpp
@@ -1,0 +1,42 @@
+#ifdef LOXPP_NAN_TAGGING
+
+#include "value.h"
+
+#include <bit>
+#include <cstdio>
+
+bool operator!(Value v) {
+    return v.bits == detail::VAL_FALSE || v.bits == detail::VAL_NIL;
+}
+
+bool operator==(const Value& a, const Value& b) {
+    // Numbers must compare as IEEE 754 doubles so that:
+    //   +0.0 == -0.0  (different bits, same double value)
+    //   NaN  != NaN   (same bits, but IEEE 754 mandates NaN != NaN)
+    if (is<Number>(a) && is<Number>(b))
+        return std::bit_cast<double>(a.bits) == std::bit_cast<double>(b.bits);
+    // For all other types the encoding is unique — same bits means equal.
+    return a.bits == b.bits;
+}
+
+std::string stringify(const Value& value) {
+    if (is<bool>(value))
+        return as<bool>(value) ? "true" : "false";
+    if (is<Nil>(value))
+        return "nil";
+    if (is<Obj*>(value))
+        return stringifyObj(as<Obj*>(value));
+    char buf[64];
+    std::snprintf(buf, sizeof(buf), "%g", as<Number>(value));
+    return buf;
+}
+
+void printValue(const Value& value) {
+    std::printf("%s", stringify(value).c_str());
+}
+
+uint8_t ValueArray::size() const { return m_count; }
+
+void ValueArray::write(Value value) { at(m_count++) = value; }
+
+#endif // LOXPP_NAN_TAGGING

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,7 @@ set(ALLOC_SRCS
     ${PROJECT_SOURCE_DIR}/src/memory_manager.cpp
     ${PROJECT_SOURCE_DIR}/src/object.cpp
     ${PROJECT_SOURCE_DIR}/src/table.cpp
-    ${PROJECT_SOURCE_DIR}/src/value.cpp
+    ${LOXPP_VALUE_SRC}
 )
 
 set(FULL_SRCS
@@ -14,7 +14,7 @@ set(FULL_SRCS
     ${PROJECT_SOURCE_DIR}/src/parser.cpp
     ${PROJECT_SOURCE_DIR}/src/chunk.cpp
     ${PROJECT_SOURCE_DIR}/src/debug.cpp
-    ${PROJECT_SOURCE_DIR}/src/value.cpp
+    ${LOXPP_VALUE_SRC}
     ${PROJECT_SOURCE_DIR}/src/object.cpp
     ${PROJECT_SOURCE_DIR}/src/table.cpp
     ${PROJECT_SOURCE_DIR}/src/memory_manager.cpp
@@ -57,6 +57,15 @@ target_include_directories(test_list_gc PRIVATE ${PROJECT_SOURCE_DIR}/src)
 target_compile_definitions(test_stress_gc PRIVATE LOXPP_STRESS_GC)
 target_compile_definitions(test_gc_regression PRIVATE LOXPP_STRESS_GC)
 target_compile_definitions(test_list_gc PRIVATE LOXPP_STRESS_GC)
+
+if(LOXPP_NAN_TAGGING)
+    foreach(_target
+        test_parser_vm test_parser_bytecode test_table test_allocator
+        test_local_variables test_control_flow test_vm_runtime test_closures
+        test_stress_gc test_gc_regression test_inheritance test_list test_list_gc)
+        target_compile_definitions(${_target} PRIVATE LOXPP_NAN_TAGGING)
+    endforeach()
+endif()
 
 target_link_libraries(test_scanner PRIVATE GTest::GTest GTest::Main)
 target_link_libraries(test_parser_vm PRIVATE GTest::GTest GTest::Main)

--- a/test/test_closures.cpp
+++ b/test/test_closures.cpp
@@ -44,7 +44,7 @@ TEST_F(ClosureTest, BasicCapture_ReadsCorrectValue) {
               InterpretResult::OK);
     auto v = h.getGlobal("result");
     ASSERT_TRUE(v.has_value());
-    EXPECT_DOUBLE_EQ(std::get<Number>(*v), 8.0);
+    EXPECT_DOUBLE_EQ(as<Number>(*v), 8.0);
     EXPECT_EQ(h.stackDepth(), 0);
 }
 
@@ -75,9 +75,9 @@ TEST_F(ClosureTest, MutationViaUpvalue) {
     ASSERT_TRUE(a.has_value());
     ASSERT_TRUE(b.has_value());
     ASSERT_TRUE(d.has_value());
-    EXPECT_DOUBLE_EQ(std::get<Number>(*a), 1.0);
-    EXPECT_DOUBLE_EQ(std::get<Number>(*b), 2.0);
-    EXPECT_DOUBLE_EQ(std::get<Number>(*d), 3.0);
+    EXPECT_DOUBLE_EQ(as<Number>(*a), 1.0);
+    EXPECT_DOUBLE_EQ(as<Number>(*b), 2.0);
+    EXPECT_DOUBLE_EQ(as<Number>(*d), 3.0);
     EXPECT_EQ(h.stackDepth(), 0);
 }
 
@@ -123,9 +123,9 @@ TEST_F(ClosureTest, SharedUpvalue_IndependentCounters) {
     auto x = h.getGlobal("x");
     ASSERT_TRUE(a.has_value() && b.has_value() && x.has_value());
     // c1 and c2 each have their own upvalue — independent state.
-    EXPECT_DOUBLE_EQ(std::get<Number>(*a), 1.0);
-    EXPECT_DOUBLE_EQ(std::get<Number>(*b), 2.0);
-    EXPECT_DOUBLE_EQ(std::get<Number>(*x), 1.0);
+    EXPECT_DOUBLE_EQ(as<Number>(*a), 1.0);
+    EXPECT_DOUBLE_EQ(as<Number>(*b), 2.0);
+    EXPECT_DOUBLE_EQ(as<Number>(*x), 1.0);
     EXPECT_EQ(h.stackDepth(), 0);
 }
 
@@ -149,7 +149,7 @@ TEST_F(ClosureTest, NestedClosure_UpvalueOfUpvalue) {
               InterpretResult::OK);
     auto v = h.getGlobal("result");
     ASSERT_TRUE(v.has_value());
-    EXPECT_DOUBLE_EQ(std::get<Number>(*v), 42.0);
+    EXPECT_DOUBLE_EQ(as<Number>(*v), 42.0);
     EXPECT_EQ(h.stackDepth(), 0);
 }
 
@@ -172,8 +172,8 @@ TEST_F(ClosureTest, NestedClosure_MutationPropagates) {
     auto a = h.getGlobal("a");
     auto b = h.getGlobal("b");
     ASSERT_TRUE(a.has_value() && b.has_value());
-    EXPECT_DOUBLE_EQ(std::get<Number>(*a), 1.0);
-    EXPECT_DOUBLE_EQ(std::get<Number>(*b), 2.0);
+    EXPECT_DOUBLE_EQ(as<Number>(*a), 1.0);
+    EXPECT_DOUBLE_EQ(as<Number>(*b), 2.0);
     EXPECT_EQ(h.stackDepth(), 0);
 }
 
@@ -197,6 +197,6 @@ TEST_F(ClosureTest, ClosedOverVarSurvivesBlockExit) {
               InterpretResult::OK);
     auto v = h.getGlobal("result");
     ASSERT_TRUE(v.has_value());
-    EXPECT_DOUBLE_EQ(std::get<Number>(*v), 99.0);
+    EXPECT_DOUBLE_EQ(as<Number>(*v), 99.0);
     EXPECT_EQ(h.stackDepth(), 0);
 }

--- a/test/test_control_flow.cpp
+++ b/test/test_control_flow.cpp
@@ -14,13 +14,13 @@
 #include <cmath>
 
 static void expect_num(const Value& v, double expected) {
-    ASSERT_TRUE(std::holds_alternative<Number>(v)) << "expected Number";
-    EXPECT_NEAR(std::get<Number>(v), expected, 1e-9);
+    ASSERT_TRUE(is<Number>(v)) << "expected Number";
+    EXPECT_NEAR(as<Number>(v), expected, 1e-9);
 }
 
 static void expect_bool(const Value& v, bool expected) {
-    ASSERT_TRUE(std::holds_alternative<bool>(v)) << "expected bool";
-    EXPECT_EQ(std::get<bool>(v), expected);
+    ASSERT_TRUE(is<bool>(v)) << "expected bool";
+    EXPECT_EQ(as<bool>(v), expected);
 }
 
 // ===========================================================================

--- a/test/test_gc_regression.cpp
+++ b/test/test_gc_regression.cpp
@@ -87,5 +87,5 @@ TEST(GcRegression, Bug32_ObjFunctionUnrootedInLocalFunDeclaration) {
               InterpretResult::OK);
     auto v = h.getGlobal("result");
     ASSERT_TRUE(v.has_value());
-    EXPECT_DOUBLE_EQ(std::get<Number>(*v), 42.0);
+    EXPECT_DOUBLE_EQ(as<Number>(*v), 42.0);
 }

--- a/test/test_local_variables.cpp
+++ b/test/test_local_variables.cpp
@@ -18,8 +18,8 @@
 // ===========================================================================
 
 static void expect_num(const Value& v, double expected) {
-    ASSERT_TRUE(std::holds_alternative<Number>(v)) << "expected Number";
-    EXPECT_NEAR(std::get<Number>(v), expected, 1e-9);
+    ASSERT_TRUE(is<Number>(v)) << "expected Number";
+    EXPECT_NEAR(as<Number>(v), expected, 1e-9);
 }
 
 // ===========================================================================

--- a/test/test_parser_vm.cpp
+++ b/test/test_parser_vm.cpp
@@ -10,21 +10,21 @@ class ParserVMTest : public ::testing::Test {};
 
 static void expect_num(const std::string& expr, double expected) {
     Value v = eval_expr(expr);
-    ASSERT_TRUE(std::holds_alternative<Number>(v))
+    ASSERT_TRUE(is<Number>(v))
         << "  expr: " << expr << "\n  expected number, got different type";
-    EXPECT_NEAR(std::get<Number>(v), expected, 1e-9) << "  expr: " << expr;
+    EXPECT_NEAR(as<Number>(v), expected, 1e-9) << "  expr: " << expr;
 }
 
 static void expect_bool(const std::string& expr, bool expected) {
     Value v = eval_expr(expr);
-    ASSERT_TRUE(std::holds_alternative<bool>(v))
+    ASSERT_TRUE(is<bool>(v))
         << "  expr: " << expr << "\n  expected bool, got different type";
-    EXPECT_EQ(std::get<bool>(v), expected) << "  expr: " << expr;
+    EXPECT_EQ(as<bool>(v), expected) << "  expr: " << expr;
 }
 
 static void expect_nil(const std::string& expr) {
     Value v = eval_expr(expr);
-    EXPECT_TRUE(std::holds_alternative<Nil>(v))
+    EXPECT_TRUE(is<Nil>(v))
         << "  expr: " << expr << "\n  expected nil, got different type";
 }
 

--- a/test/test_stress_gc.cpp
+++ b/test/test_stress_gc.cpp
@@ -39,7 +39,7 @@ TEST_F(StressGCTest, GlobalFunctionSurvivesGC) {
               InterpretResult::OK);
     auto v = h.getGlobal("result");
     ASSERT_TRUE(v.has_value());
-    EXPECT_DOUBLE_EQ(std::get<Number>(*v), 3.0);
+    EXPECT_DOUBLE_EQ(as<Number>(*v), 3.0);
     EXPECT_EQ(h.stackDepth(), 0);
 }
 
@@ -61,7 +61,7 @@ TEST_F(StressGCTest, LocalFunctionSurvivesGC) {
               InterpretResult::OK);
     auto v = h.getGlobal("result");
     ASSERT_TRUE(v.has_value());
-    EXPECT_DOUBLE_EQ(std::get<Number>(*v), 42.0);
+    EXPECT_DOUBLE_EQ(as<Number>(*v), 42.0);
     EXPECT_EQ(h.stackDepth(), 0);
 }
 
@@ -84,7 +84,7 @@ TEST_F(StressGCTest, ClosureCaptureSurvivesGC) {
               InterpretResult::OK);
     auto v = h.getGlobal("result");
     ASSERT_TRUE(v.has_value());
-    EXPECT_DOUBLE_EQ(std::get<Number>(*v), 2.0);
+    EXPECT_DOUBLE_EQ(as<Number>(*v), 2.0);
     EXPECT_EQ(h.stackDepth(), 0);
 }
 
@@ -104,7 +104,7 @@ TEST_F(StressGCTest, RecursionSurvivesGC) {
               InterpretResult::OK);
     auto v = h.getGlobal("result");
     ASSERT_TRUE(v.has_value());
-    EXPECT_DOUBLE_EQ(std::get<Number>(*v), 55.0);
+    EXPECT_DOUBLE_EQ(as<Number>(*v), 55.0);
     EXPECT_EQ(h.stackDepth(), 0);
 }
 

--- a/test/test_vm_runtime.cpp
+++ b/test/test_vm_runtime.cpp
@@ -24,25 +24,22 @@ static void expect_global_num(VMTestHarness& h, const std::string& name,
                               double expected) {
     auto v = h.getGlobal(name);
     ASSERT_TRUE(v.has_value()) << "  global '" << name << "' not defined";
-    ASSERT_TRUE(std::holds_alternative<Number>(*v))
-        << "  global '" << name << "' expected Number";
-    EXPECT_NEAR(std::get<Number>(*v), expected, 1e-9);
+    ASSERT_TRUE(is<Number>(*v)) << "  global '" << name << "' expected Number";
+    EXPECT_NEAR(as<Number>(*v), expected, 1e-9);
 }
 
 static void expect_global_bool(VMTestHarness& h, const std::string& name,
                                bool expected) {
     auto v = h.getGlobal(name);
     ASSERT_TRUE(v.has_value()) << "  global '" << name << "' not defined";
-    ASSERT_TRUE(std::holds_alternative<bool>(*v))
-        << "  global '" << name << "' expected bool";
-    EXPECT_EQ(std::get<bool>(*v), expected);
+    ASSERT_TRUE(is<bool>(*v)) << "  global '" << name << "' expected bool";
+    EXPECT_EQ(as<bool>(*v), expected);
 }
 
 static void expect_global_nil(VMTestHarness& h, const std::string& name) {
     auto v = h.getGlobal(name);
     ASSERT_TRUE(v.has_value()) << "  global '" << name << "' not defined";
-    EXPECT_TRUE(std::holds_alternative<Nil>(*v))
-        << "  global '" << name << "' expected nil";
+    EXPECT_TRUE(is<Nil>(*v)) << "  global '" << name << "' expected nil";
 }
 
 static void expect_global_str(VMTestHarness& h, const std::string& name,


### PR DESCRIPTION
## Summary

- Adds `LOXPP_NAN_TAGGING` CMake option that encodes all `Value` types (`double`, `bool`, `Nil`, `Obj*`) in a single 8-byte `uint64_t` using quiet-NaN bit patterns, halving VM stack and constant-pool memory footprint
- Implementation is fully isolated in `src/value_nan.cpp` and gated behind `#ifdef LOXPP_NAN_TAGGING` — zero changes to `vm.cpp`, `compiler.cpp`, `table.cpp`, or `memory_manager.cpp`
- Upgrades the project to C++20 globally (required for `std::bit_cast`)
- Replaces raw `std::holds_alternative`/`std::get` calls in test files with the stable public `is<T>`/`as<T>` API

## Bit layout

```
Normal double:  (bits & QNAN) != QNAN
QNAN:           0x7FFC000000000000
OBJ_TAG:        QNAN | SIGN_BIT = 0xFFFC000000000000
VAL_NIL:        QNAN | 0x01
VAL_FALSE:      QNAN | 0x02
VAL_TRUE:       QNAN | 0x03
Obj*:           OBJ_TAG | ptr
```

CPU-generated arithmetic NaN (`0x7FF8000000000000`) does not set bit 50, so it correctly passes as a `Number`.

## Test plan

- [ ] Default (variant) build: `cmake -B build && cmake --build build && ctest --test-dir build`
- [ ] NaN-tagged build: `cmake -B build-nan -DLOXPP_NAN_TAGGING=ON && cmake --build build-nan && ctest --test-dir build-nan`
- [ ] Both paths pass 15/15 tests identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)