### PR TITLE
feat: iterator protocol with GET_ITER/ITER_HAS_NEXT/ITER_NEXT opcodes

### DIFF
--- a/notes/language-extension.md
+++ b/notes/language-extension.md
@@ -200,50 +200,37 @@ separate.
 
 ### foreach / iteration protocol
 
+**Implemented (milestone 7):** List and String only, via dedicated VM opcodes.
+
 **User-facing API:**
 ```lox
-// for-in syntax over any iterable
-for (var x : list) { print x; }
-for (var ch : "hello") { print ch; }   // once strings are indexable
-
-// User-defined iterable: implement iter() returning an object with
-// hasNext()/next()
-class Range {
-    init(start, end) {
-        this.start = start;
-        this.end = end;
-    }
-    iter() {
-        return RangeIter(this.start, this.end);
-    }
-}
-
-class RangeIter {
-    init(cur, end) {
-        this.cur = cur;
-        this.end = end;
-    }
-    hasNext() { return this.cur < this.end; }
-    next() {
-        var val = this.cur;
-        this.cur = this.cur + 1;
-        return val;
-    }
-}
-
-for (var i : Range(0, 5)) { print i; }  // 0 1 2 3 4
+for (var x in [1, 2, 3]) { print x; }   // 1 2 3
+for (var ch in "hello") { print ch; }    // h e l l o
 ```
 
-**Justification:** `for (var x : expr)` desugars to:
+Iterating over any other value is a runtime error.
+
+**Implementation:** `for (var x in expr)` compiles to three new opcodes:
+
+- `GET_ITER` — pops a List or String, pushes an `ObjIterator{collection, cursor=0}`
+  in-place (GC-safe: replaces the stack slot rather than pop+alloc+push)
+- `ITER_HAS_NEXT` — pops an iterator copy, pushes `true` if `cursor < length`
+- `ITER_NEXT` — pops an iterator copy, pushes the element at `cursor` and advances it
+
+The compiler emits two hidden locals (`(iter)` + item variable) instead of the
+previous three (`(seq)` + `(idx)` + item). This eliminates the `len()` call and
+index arithmetic on every iteration.
+
+**Deferred — user-defined iterables:** User classes can opt in by implementing
+`iter()` returning an object with `hasNext()` / `next()`. The planned desugaring:
 ```lox
+// for (var x in expr) where expr is a user-defined iterable would desugar to:
 var _it = expr.iter();
 while (_it.hasNext()) { var x = _it.next(); ... }
 ```
 Explicit `hasNext()` / `next()` (vs Python's `StopIteration` exception) avoids
-needing exceptions in the language. Native List and String provide built-in
-iterators; user types opt in by implementing `iter()`. This is essentially
-Java's `Iterable`/`Iterator` — familiar, teachable, no new syntax beyond `for
-(var x : ...)`.
+needing exceptions in the language. This is essentially Java's
+`Iterable`/`Iterator` — familiar, teachable, no new syntax. Not yet implemented.
 
 ---
 

--- a/spec/04-semantics.md
+++ b/spec/04-semantics.md
@@ -312,14 +312,41 @@ Where:
 - `increment` is an expression evaluated after each iteration body; if omitted
   it is skipped.
 
+### `for`-in Statement
+
+```
+for ( var x in expr ) body
+```
+
+Iterates over the elements of a sequence in order.
+
+1. Evaluate `expr` exactly once. The result must be a **List** or a **String**;
+   any other value is a **runtime error** ("Value is not iterable.").
+2. An internal **iterator** is created, holding a reference to the sequence and
+   a cursor starting at `0`. The iterator is not accessible to user code.
+3. Before each iteration, the cursor is compared to the length of the sequence.
+   If `cursor ≥ length`, the loop exits.
+4. Otherwise, the element at `cursor` is bound to `x` and `body` executes.
+   - For a **List**: `x` is bound to the element value.
+   - For a **String**: `x` is bound to a single-character String.
+5. After the body, the cursor advances by one and the loop repeats from step 3.
+
+`x` is scoped to the loop body; it is not accessible after the loop exits.
+
+**Mutation during iteration**: modifying the List while iterating is defined.
+Elements appended to the List at indices beyond the current cursor will be
+visited. Removing elements is not directly possible (List has no `remove`).
+
+**`break`** and **`continue`** work as described below.
+
 ### `break` Statement
 
 ```
 break ;
 ```
 
-Immediately exits the innermost enclosing `while`, `for`, or `switch`
-statement. Any local variables declared inside the construct since its opening
+Immediately exits the innermost enclosing `while`, `for`, `for`-in, or
+`switch` statement. Any local variables declared inside the construct since its opening
 are destroyed. Executing `break` outside a loop or switch is a **static
 error**.
 
@@ -333,6 +360,8 @@ Skips the remainder of the current loop body and jumps to the next iteration:
 - In a `while` loop: jumps to re-evaluating the condition.
 - In a `for` loop: jumps to evaluating the increment expression, then the
   condition.
+- In a `for`-in loop: jumps to checking whether the iterator has a next
+  element (cursor advance already happened via `ITER_NEXT` before the body).
 
 Any local variables declared inside the loop body since the top of the current
 iteration are destroyed. Executing `continue` inside a `switch` that is itself

--- a/spec/README.md
+++ b/spec/README.md
@@ -78,6 +78,7 @@ variant) and adds the following:
 | `str()` built-in | Added in Lox++ |
 | Classes (`class`, `super`, `this`) | Added in Lox++ |
 | List type with `[]` literal and indexing | Added in Lox++ |
+| `for (var x in seq)` iteration over List and String | Added in Lox++ |
 
 ---
 

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -53,6 +53,9 @@ enum class Op : Byte {
     GET_INDEX,    // pops index then list/string; pushes element/char
     SET_INDEX, // pops value, index, list; sets list[index]=value; pushes value
     IN,        // pops seq (rhs) then elem (lhs); pushes bool membership result
+    GET_ITER,  // pops List|String → pushes ObjIterator{cursor=0}
+    ITER_HAS_NEXT, // pops iterator copy → pushes bool (cursor < length)
+    ITER_NEXT, // pops iterator copy → pushes element at cursor, advances cursor
 };
 
 inline Op toOpcode(Byte byte) { return static_cast<Op>(byte); }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -476,71 +476,46 @@ void Compiler::forInStatement(const Token& itemName) {
     // At entry: 'for' '(' 'var' itemName 'in' have been consumed.
     // Caller (forStatement) owns beginScope()/endScope().
 
-    // 1. Evaluate sequence expression and store in hidden local.
+    // 1. Evaluate iterable expression; GET_ITER replaces it with an
+    // ObjIterator.
     expression();
     m_parser->consume(TokenType::RIGHT_PAREN, "Expect ')' after sequence.");
+    emitByte(Op::GET_ITER);
 
-    Token seqToken{TokenType::IDENTIFIER, "(seq)", m_parser->m_previous.line};
-    addLocal(seqToken);
+    Token iterToken{TokenType::IDENTIFIER, "(iter)", m_parser->m_previous.line};
+    addLocal(iterToken);
     markInitialized();
+    int iterSlot = m_localCount - 1;
 
-    // 2. Hidden index local = 0.
-    emitBytes(Op::CONSTANT, makeConstant(from<Number>(0.0)));
-    Token idxToken{TokenType::IDENTIFIER, "(idx)", m_parser->m_previous.line};
-    addLocal(idxToken);
-    markInitialized();
-
-    // 3. Item variable = nil.
+    // 2. Item variable starts as nil.
     emitByte(Op::NIL);
     addLocal(itemName);
     markInitialized();
-
-    int seqSlot = m_localCount - 3;
-    int idxSlot = m_localCount - 2;
     int itemSlot = m_localCount - 1;
 
-    // 4. Loop header (condition re-entry point).
+    // 3. Loop header (re-entry point for LOOP and continue).
     int loopStart = static_cast<int>(getCurrentChunk()->size());
     m_loopStack.push_back({loopStart, m_localCount, {}});
 
-    // 5. Exit condition: idx < len(seq)
-    emitBytes(Op::GET_LOCAL, static_cast<uint8_t>(idxSlot));
-    Token lenTok{TokenType::IDENTIFIER, "len", m_parser->m_previous.line};
-    emitBytes(Op::GET_GLOBAL, identifierConstant(lenTok));
-    emitBytes(Op::GET_LOCAL, static_cast<uint8_t>(seqSlot));
-    emitBytes(Op::CALL, 1);
-    emitByte(Op::LESS); // idx < len(seq)?
+    // 4. Check: push iterator copy, ITER_HAS_NEXT → bool on stack.
+    emitBytes(Op::GET_LOCAL, static_cast<uint8_t>(iterSlot));
+    emitByte(Op::ITER_HAS_NEXT);
     int exitJump = emitJump(Op::JUMP_IF_FALSE);
-    emitByte(Op::POP);
+    emitByte(Op::POP); // discard true
 
-    // 6. Jump over increment to body.
-    int bodyJump = emitJump(Op::JUMP);
-
-    // 7. Increment block (continue target).
-    int incrStart = static_cast<int>(getCurrentChunk()->size());
-    m_loopStack.back().start = incrStart;
-    emitBytes(Op::GET_LOCAL, static_cast<uint8_t>(idxSlot));
-    emitBytes(Op::CONSTANT, makeConstant(from<Number>(1.0)));
-    emitByte(Op::ADD);
-    emitBytes(Op::SET_LOCAL, static_cast<uint8_t>(idxSlot));
-    emitByte(Op::POP);
-    emitLoop(loopStart);
-
-    // 8. Body start: assign item = seq[idx].
-    patchJump(bodyJump);
-    emitBytes(Op::GET_LOCAL, static_cast<uint8_t>(seqSlot));
-    emitBytes(Op::GET_LOCAL, static_cast<uint8_t>(idxSlot));
-    emitByte(Op::GET_INDEX);
+    // 5. Advance: push iterator copy, ITER_NEXT → next element; assign to item.
+    emitBytes(Op::GET_LOCAL, static_cast<uint8_t>(iterSlot));
+    emitByte(Op::ITER_NEXT);
     emitBytes(Op::SET_LOCAL, static_cast<uint8_t>(itemSlot));
     emitByte(Op::POP);
 
-    // 9. User body.
+    // 6. User body.
     statement();
-    emitLoop(incrStart);
+    emitLoop(loopStart);
 
-    // 10. Exit.
+    // 7. Exit.
     patchJump(exitJump);
-    emitByte(Op::POP);
+    emitByte(Op::POP); // discard false
 
     for (int offset : m_loopStack.back().breakJumps)
         patchJump(offset);

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -186,6 +186,12 @@ int disassembleInstruction(const Chunk& chunk, const MemoryManager& mm,
         return simpleInstruction("SET_INDEX", offset, out, color);
     case Op::IN:
         return simpleInstruction("IN", offset, out, color);
+    case Op::GET_ITER:
+        return simpleInstruction("GET_ITER", offset, out, color);
+    case Op::ITER_HAS_NEXT:
+        return simpleInstruction("ITER_HAS_NEXT", offset, out, color);
+    case Op::ITER_NEXT:
+        return simpleInstruction("ITER_NEXT", offset, out, color);
     default:
         out << cc(color, kRed) << cc(color, kBold) << "UNKNOWN("
             << static_cast<unsigned>(chunk.at(offset)) << ")"

--- a/src/function.h
+++ b/src/function.h
@@ -120,6 +120,22 @@ inline bool isList(const Value& v) {
     return is<Obj*>(v) && as<Obj*>(v)->type == ObjType::LIST;
 }
 
+struct ObjIterator : public Obj {
+    Value collection; // ObjList* or ObjString* being iterated
+    int index;        // current cursor position
+
+    ObjIterator(Value coll, int idx = 0)
+        : Obj(ObjType::ITERATOR), collection(coll), index(idx) {}
+};
+
+inline bool isObjIterator(Obj* o) { return isObjType(o, ObjType::ITERATOR); }
+inline ObjIterator* asObjIterator(Obj* o) {
+    return static_cast<ObjIterator*>(o);
+}
+inline bool isIterator(const Value& v) {
+    return is<Obj*>(v) && as<Obj*>(v)->type == ObjType::ITERATOR;
+}
+
 struct ObjFile : public Obj {
     ObjClass* klass;       // shared s_fileClass; GC-tracked
     FILE* handle{nullptr}; // null when closed

--- a/src/memory_manager.cpp
+++ b/src/memory_manager.cpp
@@ -30,6 +30,8 @@ static const char* objTypeName(ObjType type) {
         return "list";
     case ObjType::FILE:
         return "file";
+    case ObjType::ITERATOR:
+        return "iterator";
     }
     return "?";
 }
@@ -189,6 +191,9 @@ void MemoryManager::traceObject(Obj* obj) {
     }
     case ObjType::FILE:
         markObject(static_cast<ObjFile*>(obj)->klass);
+        break;
+    case ObjType::ITERATOR:
+        markValue(static_cast<ObjIterator*>(obj)->collection);
         break;
     }
 }

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -51,6 +51,8 @@ std::string stringifyObj(Obj* obj) {
     }
     case ObjType::FILE:
         return "<file>";
+    case ObjType::ITERATOR:
+        return "<iterator>";
     case ObjType::LIST: {
         auto* list = static_cast<ObjList*>(obj);
         std::string result = "[";

--- a/src/object.h
+++ b/src/object.h
@@ -16,7 +16,8 @@ enum class ObjType : uint8_t {
     INSTANCE,
     BOUND_METHOD,
     LIST,
-    FILE
+    FILE,
+    ITERATOR,
 };
 
 inline uint32_t hashString(std::string_view s) {

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -920,6 +920,76 @@ InterpretResult VM::run() {
             }
             break;
         }
+        case Op::GET_ITER: {
+            // peek(0) keeps iterable on stack as GC root during create<>().
+            // Mirrors the class-instantiation pattern at vm.cpp:556-558.
+            Value iterable = peek(0);
+            if (!isList(iterable) && !isString(iterable)) {
+                runtimeError(
+                    "Value is not iterable (expected list or string).");
+                return InterpretResult::RUNTIME_ERROR;
+            }
+            ObjIterator* it = m_mm.create<ObjIterator>(iterable, 0);
+            stackTop[-1] = Value{static_cast<Obj*>(it)}; // replace in-place
+            break;
+        }
+        case Op::ITER_HAS_NEXT: {
+            Value top = pop();
+            // Invariant 1: value must be an ObjIterator (guaranteed by
+            // GET_ITER).
+            if (!isIterator(top)) {
+                runtimeError(
+                    "BUG: ITER_HAS_NEXT expects an iterator on the stack.");
+                return InterpretResult::RUNTIME_ERROR;
+            }
+            ObjIterator* it = asObjIterator(as<Obj*>(top));
+            bool has;
+            // Invariant 2: collection must be List or String (guaranteed by
+            // GET_ITER).
+            if (isList(it->collection))
+                has = it->index <
+                      (int)asObjList(as<Obj*>(it->collection))->elements.size();
+            else if (isString(it->collection))
+                has = it->index <
+                      (int)asObjString(as<Obj*>(it->collection))->chars.size();
+            else {
+                runtimeError(
+                    "BUG: ObjIterator::collection is neither list nor string.");
+                return InterpretResult::RUNTIME_ERROR;
+            }
+            push(from<bool>(has));
+            break;
+        }
+        case Op::ITER_NEXT: {
+            Value top = pop();
+            // Invariant 1: value must be an ObjIterator (guaranteed by
+            // GET_ITER).
+            if (!isIterator(top)) {
+                runtimeError(
+                    "BUG: ITER_NEXT expects an iterator on the stack.");
+                return InterpretResult::RUNTIME_ERROR;
+            }
+            ObjIterator* it = asObjIterator(as<Obj*>(top));
+            // Invariant 2: collection must be List or String (guaranteed by
+            // GET_ITER).
+            if (isList(it->collection)) {
+                push(
+                    asObjList(as<Obj*>(it->collection))->elements[it->index++]);
+            } else if (isString(it->collection)) {
+                char ch =
+                    asObjString(as<Obj*>(it->collection))->chars[it->index++];
+                // ObjIterator is GC-rooted at iterSlot on VM stack; GC is
+                // non-moving. ch is a plain char copied before makeString
+                // (which may trigger GC).
+                push(Value{static_cast<Obj*>(
+                    m_mm.makeString(std::string_view{&ch, 1}))});
+            } else {
+                runtimeError(
+                    "BUG: ObjIterator::collection is neither list nor string.");
+                return InterpretResult::RUNTIME_ERROR;
+            }
+            break;
+        }
         }
     }
 

--- a/test/test_parser_bytecode.cpp
+++ b/test/test_parser_bytecode.cpp
@@ -261,44 +261,33 @@ TEST_F(SequenceBytecodeTest, InExpr_StringSubstring) {
 
 // `for (var x in [1]) {}` compiles to (at script level):
 //
-//   Locals: slot0="" (implicit), slot1=(seq), slot2=(idx), slot3=x
-//   Constants: slot0='1' (list element; 1.0 increment deduped to same slot),
-//              slot1='0' (initial idx=0), slot2='len' (global name)
+//   Locals: slot0="" (implicit), slot1=(iter), slot2=x
+//   Constants: slot0='1' (list element)
 //
-// The loop uses the jump-around-increment pattern so that `continue` jumps
-// to incrStart (offset 23) rather than back to the condition.
+// GET_ITER replaces the list on the stack with an ObjIterator in-place.
+// Each loop iteration: GET_LOCAL 1 (iter copy) → ITER_HAS_NEXT → bool check,
+// then GET_LOCAL 1 (iter copy) → ITER_NEXT → element → SET_LOCAL 2.
+// continue re-enters at loopStart (offset 6), which re-checks ITER_HAS_NEXT.
 TEST_F(SequenceBytecodeTest, ForIn_EmptyBodyBytecode) {
     std::string bytecode = compile_program_to_bytecode("for (var x in [1]) {}");
     std::string expected =
         "0: CONSTANT 0 ('1')\n" // list element
-        "2: BUILD_LIST 1\n"     // push [1] as (seq)
-        "4: CONSTANT 1 ('0')\n" // push 0 as (idx)
-        "6: NIL\n"              // push nil as item x
-        "7: GET_LOCAL 2\n"      // condition: push (idx)
-        "9: GET_GLOBAL 2 ('len')\n"
-        "11: GET_LOCAL 1\n" // push (seq)
-        "13: CALL 1\n"      // len(seq)
-        "15: LESS\n"        // idx < len(seq)
-        "16: JUMP_IF_FALSE 16 -> 45\n"
-        "19: POP\n"
-        "20: JUMP 20 -> 34\n"    // jump over increment to body
-        "23: GET_LOCAL 2\n"      // increment: push (idx)
-        "25: CONSTANT 0 ('1')\n" // 1.0 deduped with list-element slot
-        "27: ADD\n"
-        "28: SET_LOCAL 2\n" // idx++
-        "30: POP\n"
-        "31: LOOP 31 -> 7\n" // back to condition
-        "34: GET_LOCAL 1\n"  // body: push (seq)
-        "36: GET_LOCAL 2\n"  // push (idx)
-        "38: GET_INDEX\n"    // seq[idx]
-        "39: SET_LOCAL 3\n"  // x = seq[idx]
-        "41: POP\n"
-        "42: LOOP 42 -> 23\n" // back to increment
-        "45: POP\n"           // discard condition on exit
-        "46: POP\n"           // endScope: x
-        "47: POP\n"           // endScope: (idx)
-        "48: POP\n"           // endScope: (seq)
-        "49: NIL\n"
-        "50: RETURN\n";
+        "2: BUILD_LIST 1\n"     // push [1]
+        "4: GET_ITER\n"    // replace [1] with ObjIterator → (iter) at slot 1
+        "5: NIL\n"         // push nil → x at slot 2
+        "6: GET_LOCAL 1\n" // loopStart: push (iter) copy
+        "8: ITER_HAS_NEXT\n" // pop copy, push bool
+        "9: JUMP_IF_FALSE 9 -> 22\n"
+        "12: POP\n"         // discard true
+        "13: GET_LOCAL 1\n" // push (iter) copy
+        "15: ITER_NEXT\n"   // pop copy, push next element + advance cursor
+        "16: SET_LOCAL 2\n" // x = element
+        "18: POP\n"
+        "19: LOOP 19 -> 6\n" // back to loopStart
+        "22: POP\n"          // discard false
+        "23: POP\n"          // endScope: x
+        "24: POP\n"          // endScope: (iter)
+        "25: NIL\n"
+        "26: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }


### PR DESCRIPTION
## Summary

- Replace the index-based `for (var x in seq)` desugaring with a proper iterator protocol backed by a new `ObjIterator` heap object and three dedicated VM opcodes (`GET_ITER`, `ITER_HAS_NEXT`, `ITER_NEXT`)
- `GET_ITER` converts a List or String to an `ObjIterator{collection, cursor=0}` in-place on the stack (GC-safe: replaces the slot rather than pop+alloc+push)
- `ITER_HAS_NEXT` / `ITER_NEXT` each assert two runtime invariants — (1) stack value is an `ObjIterator`, (2) `collection` is List or String — and crash loudly if violated
- `forInStatement()` now emits **2 hidden locals** (`(iter)` + item) instead of 3 (`(seq)` + `(idx)` + item); bytecode shrinks from **50 → 27 bytes** for the minimal case; the `len()` call and index arithmetic per iteration are eliminated
- `ObjIterator` is fully GC-integrated (`traceObject` marks `collection`, `objTypeName` and `stringifyObj` handle the new type)
- Scope: List and String only; user-defined iterables (`iter()`/`hasNext()`/`next()`) are deferred

## Test plan

- [x] All 15 existing tests pass (`ctest` with `LOXPP_STRESS_GC=ON`)
- [x] `TestParserBytecode::ForIn_EmptyBodyBytecode` updated to reflect new 27-byte sequence
- [x] `TestParserVM` for-in tests (list iteration, string iteration, break, continue, nested loops) pass without modification
- [x] clang-format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)