### PR TITLE
feat: add List methods (append, pop, len, remove)

### DIFF
--- a/examples/remove.lox
+++ b/examples/remove.lox
@@ -1,0 +1,20 @@
+// Demonstrates list.remove(value):
+//   - removes the first occurrence of value
+//   - runtime error if value is not present
+//
+// Pair `in` with `remove` for guarded removal.
+
+var cart = ["apples", "bread", "milk", "bread"];
+print cart;  // [apples, bread, milk, bread]
+
+cart.remove("milk");
+print cart;  // [apples, bread, bread]
+
+// Only the first "bread" is removed
+cart.remove("bread");
+print cart;  // [apples, bread]
+
+// remove() also works with numbers
+var nums = [3, 1, 4, 1, 5];
+nums.remove(4);
+print nums;  // [3, 1, 1, 5]

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -701,6 +701,29 @@ InterpretResult VM::run() {
                     list->elements.pop_back();
                     pop(); // receiver
                     push(val);
+                } else if (name->chars == "remove") {
+                    if (argCount != 1) {
+                        runtimeError("'remove' expects 1 argument but got %d.",
+                                     argCount);
+                        return InterpretResult::RUNTIME_ERROR;
+                    }
+                    Value target = peek(0);
+                    auto& elems = list->elements;
+                    bool found = false;
+                    for (int i = 0; i < static_cast<int>(elems.size()); i++) {
+                        if (elems[i] == target) {
+                            elems.erase(elems.begin() + i);
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (!found) {
+                        runtimeError("Value not found in list.");
+                        return InterpretResult::RUNTIME_ERROR;
+                    }
+                    pop(); // arg
+                    pop(); // receiver
+                    push(from<Nil>(Nil{}));
                 } else {
                     runtimeError("Undefined method '%s' on list.",
                                  name->chars.c_str());

--- a/test/test_list.cpp
+++ b/test/test_list.cpp
@@ -469,6 +469,71 @@ TEST(List, LenOnNonList) {
 }
 
 // ---------------------------------------------------------------------------
+// remove
+// ---------------------------------------------------------------------------
+
+TEST(List, RemoveMiddleElement) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("var xs = [1, 2, 3]; xs.remove(2);"), InterpretResult::OK);
+    EXPECT_EQ(h.getGlobalStr("xs"), "[1, 3]");
+}
+
+TEST(List, RemoveReturnsNil) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("var xs = [1, 2, 3]; var r = xs.remove(2);"),
+              InterpretResult::OK);
+    EXPECT_EQ(h.getGlobalStr("r"), "nil");
+}
+
+TEST(List, RemoveOnlyFirstOccurrence) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("var xs = [1, 2, 1]; xs.remove(1);"), InterpretResult::OK);
+    EXPECT_EQ(h.getGlobalStr("xs"), "[2, 1]");
+}
+
+TEST(List, RemoveFromSingleton) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("var xs = [42]; xs.remove(42);"), InterpretResult::OK);
+    EXPECT_EQ(h.getGlobalStr("xs"), "[]");
+}
+
+TEST(List, RemoveFirstElement) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("var xs = [1, 2, 3]; xs.remove(1);"), InterpretResult::OK);
+    EXPECT_EQ(h.getGlobalStr("xs"), "[2, 3]");
+}
+
+TEST(List, RemoveLastElement) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("var xs = [1, 2, 3]; xs.remove(3);"), InterpretResult::OK);
+    EXPECT_EQ(h.getGlobalStr("xs"), "[1, 2]");
+}
+
+TEST(List, RemoveNotFound) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("var xs = [1, 2, 3]; xs.remove(99);"),
+              InterpretResult::RUNTIME_ERROR);
+}
+
+TEST(List, RemoveFromEmpty) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("var xs = []; xs.remove(1);"),
+              InterpretResult::RUNTIME_ERROR);
+}
+
+TEST(List, RemoveWrongArgCount) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("var xs = [1]; xs.remove();"),
+              InterpretResult::RUNTIME_ERROR);
+}
+
+TEST(List, RemoveTooManyArgs) {
+    VMTestHarness h;
+    ASSERT_EQ(h.run("var xs = [1]; xs.remove(1, 2);"),
+              InterpretResult::RUNTIME_ERROR);
+}
+
+// ---------------------------------------------------------------------------
 // Undefined method
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `append(value)`, `pop()`, and `len()` to the `List` type as built-in methods
- Adds `List.remove(value)`: removes the first occurrence of a value; runtime error if not found (matches Python semantics)
- Adds `examples/remove.lox` demonstrating `remove()` usage

## List method reference

| Method | Args | Returns | Error |
|---|---|---|---|
| `append(value)` | 1 | `nil` | wrong arity |
| `pop()` | 0 | last element | empty list, wrong arity |
| `remove(value)` | 1 | `nil` | value not found, wrong arity |

## Test plan

- [ ] All 57 list tests pass (`./build/test/test_list`)
- [ ] `examples/remove.lox` runs and prints correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)