### PR TITLE
fix: root val in SET_INDEX map branch to prevent UAF on GC during resize

### DIFF
--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -1049,7 +1049,13 @@ InterpretResult VM::run() {
                 // Root the map: it was popped and may be a temporary; mapSet
                 // can grow the bucket array which triggers GC.
                 m_mm.pushTempRoot(map);
+                // Root val if it's an object: it was popped off the stack
+                // before mapSet, so the GC won't find it through the stack.
+                if (is<Obj*>(val))
+                    m_mm.pushTempRoot(as<Obj*>(val));
                 map->mapSet(indexVal, val);
+                if (is<Obj*>(val))
+                    m_mm.popTempRoot();
                 m_mm.popTempRoot();
                 push(val);
                 break;

--- a/test/test_gc_regression.cpp
+++ b/test/test_gc_regression.cpp
@@ -89,3 +89,49 @@ TEST(GcRegression, Bug32_ObjFunctionUnrootedInLocalFunDeclaration) {
     ASSERT_TRUE(v.has_value());
     EXPECT_DOUBLE_EQ(std::get<Number>(*v), 42.0);
 }
+
+// ---------------------------------------------------------------------------
+// Bug #58: ObjList (val) unrooted in SET_INDEX map branch (vm.cpp)
+//
+// Timeline under LOXPP_STRESS_GC:
+//   SET_INDEX handler:
+//     val = pop()        ← ObjList leaves the VM stack
+//     indexVal = pop()
+//     listVal  = pop()
+//     pushTempRoot(map)  ← map is protected
+//     map->mapSet(indexVal, val)
+//       → ObjMap::mapSet grows bucket array
+//       → VmAllocator::allocate → rawAlloc → GC fires
+//         val (ObjList) not on stack, not a temp root → swept/freed
+//       → map stores dangling pointer
+//     push(val)          ← pushes dangling pointer
+//   Later: m["key"].append(99) → isInstance() on freed ObjList → UAF
+//
+// The reproducer fills the map to 6 entries (capacity 8, load-factor 0.75
+// threshold = 6) so the 7th insert crosses the resize threshold.
+//
+// ASAN detects: heap-use-after-free in isInstance / vm.cpp::run, freed by
+// sweep(), allocated by BUILD_LIST 0.
+// ---------------------------------------------------------------------------
+
+TEST(GcRegression, Bug58_MapSetIndexUAFOnResize) {
+    VMTestHarness h;
+    // Fill map to 6 entries so the 7th insert triggers a resize, then assign
+    // a freshly-allocated list as the value. Under ASAN+STRESS_GC this aborts
+    // with a heap-use-after-free unless val is also rooted during mapSet.
+    ASSERT_EQ(h.run(R"(
+        var m = {};
+        var i = 0;
+        while (i < 6) {
+            m[i] = i;
+            i = i + 1;
+        }
+        m["key"] = [];
+        m["key"].append(99);
+        var result = m["key"][0];
+    )"),
+              InterpretResult::OK);
+    auto v = h.getGlobal("result");
+    ASSERT_TRUE(v.has_value());
+    EXPECT_DOUBLE_EQ(std::get<Number>(*v), 99.0);
+}


### PR DESCRIPTION
## Summary

Fixes #58.

### Root cause

In the `Op::SET_INDEX` handler (`vm.cpp`), `val` is popped off the VM stack before `map->mapSet(indexVal, val)` is called. When `mapSet` needs to grow its internal bucket array, `VmAllocator::allocate` → `rawAlloc` may trigger a GC cycle. At that point `val` (e.g. a freshly-allocated `ObjList`) is invisible to the GC — not on the VM stack and not a temp root — and can be collected. The map then stores, and later returns, a dangling pointer.

The `map` object itself was already correctly guarded with `pushTempRoot`/`popTempRoot`; `val` was not.

### Fix

Guard `val` with `pushTempRoot`/`popTempRoot` around `mapSet`, conditional on `is<Obj*>(val)`:

```cpp
m_mm.pushTempRoot(map);
if (is<Obj*>(val))
    m_mm.pushTempRoot(as<Obj*>(val));
map->mapSet(indexVal, val);
if (is<Obj*>(val))
    m_mm.popTempRoot();
m_mm.popTempRoot();
```

### Test

Added `GcRegression.Bug58_MapSetIndexUAFOnResize` in `test/test_gc_regression.cpp`. The test fills the map to 6 entries (capacity 8, load-factor 0.75 threshold = 6), then assigns a freshly-allocated `[]` as the 7th value, calls `.append(99)`, and reads back the result. Under `LOXPP_STRESS_GC` + ASAN, this reliably triggers the UAF before the fix and passes cleanly after.