### PR TITLE
feat: expand constant pool from 255 to 65535 (2-byte indices)

### DIFF
--- a/bootstrap/lox_interpreter.lox
+++ b/bootstrap/lox_interpreter.lox
@@ -77,7 +77,7 @@ fun loxTag(v) {
 }
 
 // ===========================================================================
-// AST ENUMS  (must stay at global scope — Lox++ restriction)
+// AST ENUMS
 // ===========================================================================
 
 enum Expr {
@@ -110,15 +110,8 @@ enum Stmt {
 }
 
 // ===========================================================================
-// ALL CLASSES + INTERPRETER LOGIC — wrapped in runInterpreter() to stay
-// under the 256-constant-per-chunk limit in Lox++.
-// ===========================================================================
-
-fun runInterpreter() {
-
-// ---------------------------------------------------------------------------
 // SCANNER
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 class Token {
     init(type, lexeme, literal, line) {
@@ -267,9 +260,9 @@ class Scanner {
     }
 }
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // PARSER
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 class Parser {
     init(tokens) {
@@ -667,9 +660,9 @@ class Parser {
     }
 }
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // RESOLVER
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 class Resolver {
     init() {
@@ -889,9 +882,9 @@ class Resolver {
     }
 }
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // ENVIRONMENT
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 class Environment {
     init(enclosing) {
@@ -940,9 +933,9 @@ class Environment {
     }
 }
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // RUNTIME OBJECTS
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 class LoxFunction {
     init(name, params, body, closure, isInitializer) {
@@ -1049,9 +1042,9 @@ class LoxNative {
     toString() { return "<native fn>"; }
 }
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // INTERPRETER
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
 class Interpreter {
     init(locals) {
@@ -1398,35 +1391,32 @@ class Interpreter {
     }
 }
 
-// ---------------------------------------------------------------------------
+// ===========================================================================
 // Entry point — reads Lox source from stdin and runs it.
-// ---------------------------------------------------------------------------
+// ===========================================================================
 
-    var source = "";
-    var ln = input();
-    while (ln != nil) {
-        source = source + ln + "\n";
-        ln = input();
-    }
-    // Remove the trailing newline we added to the last line — avoids off-by-one
-    // in line numbers for files that don't end with a newline.
-    if (len(source) > 0 and source[len(source) - 1] == "\n") {
-        source = source[0 : len(source) - 1];
-    }
-
-    var scanner = Scanner(source);
-    var tokens  = scanner.scanTokens();
-
-    var parser = Parser(tokens);
-    var stmts  = parser.parse();
-    if (scanner.hadError or parser.hadError) return;
-
-    var resolver = Resolver();
-    resolver.resolve(stmts);
-    if (resolver.hadError) return;
-
-    var interpreter = Interpreter(resolver.locals);
-    interpreter.interpret(stmts);
+var source = "";
+var ln = input();
+while (ln != nil) {
+    source = source + ln + "\n";
+    ln = input();
+}
+// Remove the trailing newline we added to the last line — avoids off-by-one
+// in line numbers for files that don't end with a newline.
+if (len(source) > 0 and source[len(source) - 1] == "\n") {
+    source = source[0 : len(source) - 1];
 }
 
-runInterpreter();
+var scanner = Scanner(source);
+var tokens  = scanner.scanTokens();
+
+var parser = Parser(tokens);
+var stmts  = parser.parse();
+if (!scanner.hadError and !parser.hadError) {
+    var resolver = Resolver();
+    resolver.resolve(stmts);
+    if (!resolver.hadError) {
+        var interpreter = Interpreter(resolver.locals);
+        interpreter.interpret(stmts);
+    }
+}

--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -14,17 +14,17 @@ void Chunk::write(Op op, int line) { write(static_cast<Byte>(op), line); }
 
 void Chunk::patch(int offset, Byte byte) { (*this)[offset] = byte; }
 
-std::optional<uint8_t> Chunk::addConstant(Value value) {
-    // O(N) scan for an existing equal constant; avoids duplicate slots (N ≤
-    // 256). Strings are interned, so ObjHandle equality (index+type) suffices.
-    for (uint8_t i = 0; i < m_constants.size(); i++) {
+std::optional<uint16_t> Chunk::addConstant(Value value) {
+    // O(N) scan for an existing equal constant; avoids duplicate slots.
+    // Strings are interned, so ObjHandle equality (index+type) suffices.
+    for (uint16_t i = 0; i < m_constants.size(); i++) {
         if (m_constants.at(i) == value)
             return i;
     }
     if (m_constants.isFull())
         return std::nullopt;
     m_constants.write(value);
-    return static_cast<uint8_t>(m_constants.size() - 1);
+    return static_cast<uint16_t>(m_constants.size() - 1);
 }
 
 int Chunk::getLine(int offset) const {
@@ -38,4 +38,4 @@ int Chunk::getLine(int offset) const {
     return 0; // Error case
 }
 
-Value Chunk::getConstant(int idx) const { return m_constants.at(idx); }
+Value Chunk::getConstant(uint16_t idx) const { return m_constants.at(idx); }

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -44,11 +44,11 @@ enum class Op : Byte {
     GET_PROPERTY,
     SET_PROPERTY,
     DEFINE_METHOD,
-    INVOKE,    // operands: name-constant-index (1 byte), arg-count (1 byte)
+    INVOKE,    // operands: name-constant-index (2 bytes), arg-count (1 byte)
     INHERIT,   // no operand — copies superclass methods into subclass
-    GET_SUPER, // 1-byte constant (method name) — binds method to 'this' from
+    GET_SUPER, // 2-byte constant (method name) — binds method to 'this' from
                // superclass
-    SUPER_INVOKE, // operands: name-constant-index (1 byte), arg-count (1 byte)
+    SUPER_INVOKE, // operands: name-constant-index (2 bytes), arg-count (1 byte)
     BUILD_LIST,   // operand: uint8 element count; pops N values, pushes ObjList
     BUILD_MAP,    // operand: uint8 pair count; pops 2*N values, pushes ObjMap
     GET_INDEX,    // pops index then list/string/map; pushes element/char/value
@@ -60,7 +60,7 @@ enum class Op : Byte {
     ITER_NEXT, // pops iterator copy → pushes element/key at cursor, advances
     MATCH_ERROR, // no operands — raises MatchError; VM never returns
     GET_TAG,     // no operands — pop ObjEnum, push ctor->tag as Number
-    INSTANCEOF,  // 1-byte constant (class name ObjString*); pop value, push
+    INSTANCEOF,  // 2-byte constant (class name ObjString*); pop value, push
                  // bool
     IS_SEQ, // no operands — pop value, push true if it is a sequence type
 };
@@ -79,8 +79,8 @@ class Chunk : std::vector<Byte> {
     void write(Byte byte, int line);
     void write(Op op, int line);
     void patch(int offset, Byte byte);
-    std::optional<uint8_t> addConstant(Value value);
-    Value getConstant(int idx) const;
+    std::optional<uint16_t> addConstant(Value value);
+    Value getConstant(uint16_t idx) const;
     const ValueArray& constants() const { return m_constants; }
     int getLine(int offset) const;
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1811,8 +1811,9 @@ Compiler::ListPatResult Compiler::compileListPattern(int subjectSlot,
             if (std::string(elem.name.lexeme) != "_") {
                 // subject[fixedCount : len(subject)]
                 emitBytes(Op::GET_LOCAL, static_cast<uint8_t>(subjectSlot));
-                emitConstantOp(Op::CONSTANT,
-                               makeConstant(Value{static_cast<double>(fixedCount)}));
+                emitConstantOp(
+                    Op::CONSTANT,
+                    makeConstant(Value{static_cast<double>(fixedCount)}));
                 emitConstantOp(Op::GET_GLOBAL, identifierConstant(lenTok));
                 emitBytes(Op::GET_LOCAL, static_cast<uint8_t>(subjectSlot));
                 emitBytes(Op::CALL, 1);

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -170,7 +170,7 @@ void Compiler::literal() {
 
 void Compiler::number() {
     double num = std::stod(m_parser->m_previous.lexeme.data(), nullptr);
-    emitBytes(Op::CONSTANT, makeConstant(from<Number>(num)));
+    emitConstantOp(Op::CONSTANT, makeConstant(from<Number>(num)));
 }
 
 void Compiler::string() {
@@ -186,7 +186,7 @@ void Compiler::string() {
         }
     }
     ObjString* s = m_mm->makeString(std::move(processed));
-    emitBytes(Op::CONSTANT, makeConstant(Value{static_cast<Obj*>(s)}));
+    emitConstantOp(Op::CONSTANT, makeConstant(Value{static_cast<Obj*>(s)}));
 }
 
 void Compiler::variable() {
@@ -275,7 +275,7 @@ void Compiler::emitDestructureLocal(const std::vector<Token>& fields) {
         }
         addLocal(field);
         emitBytes(Op::GET_LOCAL, static_cast<uint8_t>(srcSlot));
-        emitBytes(Op::GET_PROPERTY, identifierConstant(field));
+        emitConstantOp(Op::GET_PROPERTY, identifierConstant(field));
         m_locals[m_localCount - 1].depth = m_scopeDepth;
     }
 }
@@ -285,13 +285,13 @@ void Compiler::emitDestructureGlobal(const std::vector<Token>& fields) {
     hidden.type = TokenType::IDENTIFIER;
     hidden.lexeme = "#destruct";
     hidden.line = m_parser->m_previous.line;
-    uint8_t hiddenIdx = identifierConstant(hidden);
-    emitBytes(Op::DEFINE_GLOBAL, hiddenIdx);
+    uint16_t hiddenIdx = identifierConstant(hidden);
+    emitConstantOp(Op::DEFINE_GLOBAL, hiddenIdx);
 
     for (const Token& field : fields) {
-        emitBytes(Op::GET_GLOBAL, hiddenIdx);
-        emitBytes(Op::GET_PROPERTY, identifierConstant(field));
-        emitBytes(Op::DEFINE_GLOBAL, identifierConstant(field));
+        emitConstantOp(Op::GET_GLOBAL, hiddenIdx);
+        emitConstantOp(Op::GET_PROPERTY, identifierConstant(field));
+        emitConstantOp(Op::DEFINE_GLOBAL, identifierConstant(field));
     }
 }
 
@@ -336,8 +336,8 @@ void Compiler::emitDestructureSeqLocal(const std::vector<Token>& names) {
     for (int i = 0; i < static_cast<int>(names.size()); i++) {
         const Token& name = names[i];
         emitBytes(Op::GET_LOCAL, static_cast<uint8_t>(srcSlot));
-        emitBytes(Op::CONSTANT,
-                  makeConstant(from<Number>(static_cast<double>(i))));
+        emitConstantOp(Op::CONSTANT,
+                       makeConstant(from<Number>(static_cast<double>(i))));
         emitByte(Op::GET_INDEX);
         if (name.lexeme == "_") {
             emitByte(Op::POP);
@@ -361,18 +361,18 @@ void Compiler::emitDestructureSeqGlobal(const std::vector<Token>& names) {
     hidden.type = TokenType::IDENTIFIER;
     hidden.lexeme = "#destruct";
     hidden.line = m_parser->m_previous.line;
-    uint8_t hiddenIdx = identifierConstant(hidden);
-    emitBytes(Op::DEFINE_GLOBAL, hiddenIdx);
+    uint16_t hiddenIdx = identifierConstant(hidden);
+    emitConstantOp(Op::DEFINE_GLOBAL, hiddenIdx);
 
     for (int i = 0; i < static_cast<int>(names.size()); i++) {
-        emitBytes(Op::GET_GLOBAL, hiddenIdx);
-        emitBytes(Op::CONSTANT,
-                  makeConstant(from<Number>(static_cast<double>(i))));
+        emitConstantOp(Op::GET_GLOBAL, hiddenIdx);
+        emitConstantOp(Op::CONSTANT,
+                       makeConstant(from<Number>(static_cast<double>(i))));
         emitByte(Op::GET_INDEX);
         if (names[i].lexeme == "_")
             emitByte(Op::POP);
         else
-            emitBytes(Op::DEFINE_GLOBAL, identifierConstant(names[i]));
+            emitConstantOp(Op::DEFINE_GLOBAL, identifierConstant(names[i]));
     }
 }
 
@@ -401,8 +401,8 @@ void Compiler::varDeclaration() {
     if (m_scopeDepth > 0) {
         markInitialized();
     } else {
-        uint8_t nameConst = identifierConstant(name);
-        emitBytes(Op::DEFINE_GLOBAL, nameConst);
+        uint16_t nameConst = identifierConstant(name);
+        emitConstantOp(Op::DEFINE_GLOBAL, nameConst);
     }
 }
 
@@ -881,8 +881,8 @@ Compiler::compileMatchArm(int subjectSlot, int armLocalBase, int resultSlot) {
             ctorName = patName;
             emitBytes(Op::GET_LOCAL, static_cast<uint8_t>(subjectSlot));
             emitByte(Op::GET_TAG);
-            emitBytes(Op::CONSTANT,
-                      makeConstant(Value{static_cast<double>(info->tag)}));
+            emitConstantOp(Op::CONSTANT,
+                           makeConstant(Value{static_cast<double>(info->tag)}));
             emitByte(Op::EQUAL);
             missJump = emitJump(Op::JUMP_IF_FALSE);
             emitByte(Op::POP);
@@ -890,11 +890,11 @@ Compiler::compileMatchArm(int subjectSlot, int armLocalBase, int resultSlot) {
         } else if (findClass(patName)) {
             ObjString* classNameStr = m_mm->makeString(patTok.lexeme);
             m_mm->pushTempRoot(classNameStr);
-            uint8_t classNameConst =
+            uint16_t classNameConst =
                 makeConstant(Value{static_cast<Obj*>(classNameStr)});
             m_mm->popTempRoot();
             emitBytes(Op::GET_LOCAL, static_cast<uint8_t>(subjectSlot));
-            emitBytes(Op::INSTANCEOF, classNameConst);
+            emitConstantOp(Op::INSTANCEOF, classNameConst);
             missJump = emitJump(Op::JUMP_IF_FALSE);
             emitByte(Op::POP);
             compileClassPattern(subjectSlot, patTok);
@@ -1151,9 +1151,9 @@ int Compiler::compileClassPattern(int subjectSlot, const Token& patTok) {
         do {
             m_parser->consume(TokenType::IDENTIFIER, "Expect field name.");
             Token fieldTok = m_parser->m_previous;
-            uint8_t propConst = identifierConstant(fieldTok);
+            uint16_t propConst = identifierConstant(fieldTok);
             emitBytes(Op::GET_LOCAL, static_cast<uint8_t>(subjectSlot));
-            emitBytes(Op::GET_PROPERTY, propConst);
+            emitConstantOp(Op::GET_PROPERTY, propConst);
             addLocal(fieldTok);
             markInitialized();
             bindingCount++;
@@ -1217,14 +1217,14 @@ void Compiler::enumDeclaration() {
         auto* ctor =
             m_mm->create<ObjEnumCtor>(tag, arity, ctorNameStr, enumNameStr);
         m_mm->pushTempRoot(ctor);
-        uint8_t ctorConst = makeConstant(Value{static_cast<Obj*>(ctor)});
+        uint16_t ctorConst = makeConstant(Value{static_cast<Obj*>(ctor)});
         m_mm->popTempRoot(); // ctor
         m_mm->popTempRoot(); // enumNameStr
         m_mm->popTempRoot(); // ctorNameStr
 
-        uint8_t nameConst = identifierConstant(ctorTok);
-        emitBytes(Op::CONSTANT, ctorConst);
-        emitBytes(Op::DEFINE_GLOBAL, nameConst);
+        uint16_t nameConst = identifierConstant(ctorTok);
+        emitConstantOp(Op::CONSTANT, ctorConst);
+        emitConstantOp(Op::DEFINE_GLOBAL, nameConst);
 
         root->m_constructors[ctorName] = {enumName, tag, arity, fieldNames};
         root->m_enumCtors[enumName].push_back(ctorName);
@@ -1260,8 +1260,8 @@ int Compiler::compileCtorPattern(int subjectSlot, const ConstructorInfo& info,
                 auto idx = static_cast<uint8_t>(
                     std::distance(info.fieldNames.begin(), it));
                 emitBytes(Op::GET_LOCAL, static_cast<uint8_t>(subjectSlot));
-                emitBytes(Op::CONSTANT,
-                          makeConstant(Value{static_cast<double>(idx)}));
+                emitConstantOp(Op::CONSTANT,
+                               makeConstant(Value{static_cast<double>(idx)}));
                 emitByte(Op::GET_INDEX);
                 addLocal(m_parser->m_previous);
                 markInitialized();
@@ -1282,8 +1282,8 @@ int Compiler::compileCtorPattern(int subjectSlot, const ConstructorInfo& info,
                 m_parser->consume(TokenType::IDENTIFIER,
                                   "Expect binding name.");
                 emitBytes(Op::GET_LOCAL, static_cast<uint8_t>(subjectSlot));
-                emitBytes(Op::CONSTANT,
-                          makeConstant(Value{static_cast<double>(i)}));
+                emitConstantOp(Op::CONSTANT,
+                               makeConstant(Value{static_cast<double>(i)}));
                 emitByte(Op::GET_INDEX);
                 addLocal(m_parser->m_previous);
                 markInitialized();
@@ -1338,7 +1338,7 @@ void Compiler::funDeclaration() {
     m_parser->consume(TokenType::IDENTIFIER, "Expect function name.");
     Token name = m_parser->m_previous;
 
-    uint8_t nameConst = 0;
+    uint16_t nameConst = 0;
     if (m_scopeDepth > 0) {
         declareVariable();
         markInitialized(); // allow recursion inside the body
@@ -1354,30 +1354,30 @@ void Compiler::funDeclaration() {
     fn->name = m_mm->makeString(name.lexeme);
     inner.parseFunction(FunctionType::FUNCTION);
 
-    emitBytes(Op::CLOSURE, makeConstant(Value{static_cast<Obj*>(fn)}));
+    emitConstantOp(Op::CLOSURE, makeConstant(Value{static_cast<Obj*>(fn)}));
     for (int i = 0; i < fn->upvalueCount; i++) {
         emitByte(inner.m_upvalues[i].isLocal ? 1 : 0);
         emitByte(inner.m_upvalues[i].index);
     }
     if (m_scopeDepth == 0) {
-        emitBytes(Op::DEFINE_GLOBAL, nameConst);
+        emitConstantOp(Op::DEFINE_GLOBAL, nameConst);
     }
 }
 
 void Compiler::classDeclaration() {
     m_parser->consume(TokenType::IDENTIFIER, "Expect class name.");
     Token className = m_parser->m_previous;
-    uint8_t nameConst = identifierConstant(className);
+    uint16_t nameConst = identifierConstant(className);
 
     if (m_scopeDepth > 0)
         declareVariable();
 
-    emitBytes(Op::CLASS, nameConst);
+    emitConstantOp(Op::CLASS, nameConst);
 
     if (m_scopeDepth > 0) {
         markInitialized();
     } else {
-        emitBytes(Op::DEFINE_GLOBAL, nameConst);
+        emitConstantOp(Op::DEFINE_GLOBAL, nameConst);
         findRootCompiler()->m_classNames.insert(std::string(className.lexeme));
     }
 
@@ -1425,7 +1425,7 @@ void Compiler::classDeclaration() {
 
 void Compiler::method() {
     m_parser->consume(TokenType::IDENTIFIER, "Expect method name.");
-    uint8_t nameConst = identifierConstant(m_parser->m_previous);
+    uint16_t nameConst = identifierConstant(m_parser->m_previous);
 
     FunctionType type = FunctionType::METHOD;
     if (m_parser->m_previous.lexeme == "init")
@@ -1437,12 +1437,12 @@ void Compiler::method() {
     Compiler inner(fn, m_parser, m_mm, type, this);
     inner.parseFunction(type);
 
-    emitBytes(Op::CLOSURE, makeConstant(Value{static_cast<Obj*>(fn)}));
+    emitConstantOp(Op::CLOSURE, makeConstant(Value{static_cast<Obj*>(fn)}));
     for (int i = 0; i < fn->upvalueCount; i++) {
         emitByte(inner.m_upvalues[i].isLocal ? 1 : 0);
         emitByte(inner.m_upvalues[i].index);
     }
-    emitBytes(Op::DEFINE_METHOD, nameConst);
+    emitConstantOp(Op::DEFINE_METHOD, nameConst);
 }
 
 void Compiler::this_() {
@@ -1461,7 +1461,7 @@ void Compiler::super_() {
 
     m_parser->consume(TokenType::DOT, "Expect '.' after 'super'.");
     m_parser->consume(TokenType::IDENTIFIER, "Expect superclass method name.");
-    uint8_t nameConst = identifierConstant(m_parser->m_previous);
+    uint16_t nameConst = identifierConstant(m_parser->m_previous);
 
     namedVariable(Token{TokenType::THIS, "this", 0}, false); // push receiver
 
@@ -1478,21 +1478,21 @@ void Compiler::super_() {
         m_parser->consume(TokenType::RIGHT_PAREN,
                           "Expect ')' after arguments.");
         namedVariable(Token{TokenType::SUPER, "super", 0}, false);
-        emitBytes(Op::SUPER_INVOKE, nameConst);
+        emitConstantOp(Op::SUPER_INVOKE, nameConst);
         emitByte(argCount);
     } else {
         namedVariable(Token{TokenType::SUPER, "super", 0}, false);
-        emitBytes(Op::GET_SUPER, nameConst);
+        emitConstantOp(Op::GET_SUPER, nameConst);
     }
 }
 
 void Compiler::dot() {
     m_parser->consume(TokenType::IDENTIFIER, "Expect property name after '.'.");
-    uint8_t nameConst = identifierConstant(m_parser->m_previous);
+    uint16_t nameConst = identifierConstant(m_parser->m_previous);
 
     if (m_parser->m_canAssign && m_parser->match(TokenType::EQUAL)) {
         expression();
-        emitBytes(Op::SET_PROPERTY, nameConst);
+        emitConstantOp(Op::SET_PROPERTY, nameConst);
     } else if (m_parser->match(TokenType::LEFT_PAREN)) {
         // Fuse GET_PROPERTY + CALL into a single INVOKE superinstruction.
         uint8_t argCount = 0;
@@ -1506,10 +1506,10 @@ void Compiler::dot() {
         }
         m_parser->consume(TokenType::RIGHT_PAREN,
                           "Expect ')' after arguments.");
-        emitBytes(Op::INVOKE, nameConst);
+        emitConstantOp(Op::INVOKE, nameConst);
         emitByte(argCount);
     } else {
-        emitBytes(Op::GET_PROPERTY, nameConst);
+        emitConstantOp(Op::GET_PROPERTY, nameConst);
     }
 }
 
@@ -1672,7 +1672,7 @@ void Compiler::emitLoopCleanup(int targetLocalCount) {
         emitByte(Op::POP);
 }
 
-uint8_t Compiler::makeConstant(Value value) {
+uint16_t Compiler::makeConstant(Value value) {
     auto constant = getCurrentChunk()->addConstant(value);
     if (!constant) {
         m_parser->error("Too many constants in one chunk.");
@@ -1681,35 +1681,43 @@ uint8_t Compiler::makeConstant(Value value) {
     return *constant;
 }
 
-uint8_t Compiler::identifierConstant(const Token& name) {
+uint16_t Compiler::identifierConstant(const Token& name) {
     ObjString* s = m_mm->makeString(name.lexeme);
     return makeConstant(Value{static_cast<Obj*>(s)});
 }
 
+void Compiler::emitConstantOp(Op op, uint16_t idx) {
+    emitByte(op);
+    emitByte(static_cast<Byte>((idx >> 8) & 0xff));
+    emitByte(static_cast<Byte>(idx & 0xff));
+}
+
 void Compiler::namedVariable(const Token& name, bool canAssign) {
-    Op getOp, setOp;
     int slot = resolveLocal(name);
-    uint8_t operand;
-
     if (slot != -1) {
-        getOp = Op::GET_LOCAL;
-        setOp = Op::SET_LOCAL;
-        operand = static_cast<uint8_t>(slot);
-    } else if ((slot = resolveUpvalue(name)) != -1) {
-        getOp = Op::GET_UPVALUE;
-        setOp = Op::SET_UPVALUE;
-        operand = static_cast<uint8_t>(slot);
-    } else {
-        getOp = Op::GET_GLOBAL;
-        setOp = Op::SET_GLOBAL;
-        operand = identifierConstant(name);
+        if (canAssign && m_parser->match(TokenType::EQUAL)) {
+            expression();
+            emitBytes(Op::SET_LOCAL, static_cast<Byte>(slot));
+        } else {
+            emitBytes(Op::GET_LOCAL, static_cast<Byte>(slot));
+        }
+        return;
     }
-
+    if ((slot = resolveUpvalue(name)) != -1) {
+        if (canAssign && m_parser->match(TokenType::EQUAL)) {
+            expression();
+            emitBytes(Op::SET_UPVALUE, static_cast<Byte>(slot));
+        } else {
+            emitBytes(Op::GET_UPVALUE, static_cast<Byte>(slot));
+        }
+        return;
+    }
+    uint16_t constIdx = identifierConstant(name);
     if (canAssign && m_parser->match(TokenType::EQUAL)) {
         expression();
-        emitBytes(setOp, operand);
+        emitConstantOp(Op::SET_GLOBAL, constIdx);
     } else {
-        emitBytes(getOp, operand);
+        emitConstantOp(Op::GET_GLOBAL, constIdx);
     }
 }
 
@@ -1767,11 +1775,11 @@ Compiler::ListPatResult Compiler::compileListPattern(int subjectSlot,
     // ---- Length check: len(subject) vs fixedCount -------------------------
     // Inline call: GET_GLOBAL "len"; GET_LOCAL subject; CALL 1
     Token lenTok{TokenType::IDENTIFIER, "len", m_parser->m_previous.line};
-    emitBytes(Op::GET_GLOBAL, identifierConstant(lenTok));
+    emitConstantOp(Op::GET_GLOBAL, identifierConstant(lenTok));
     emitBytes(Op::GET_LOCAL, static_cast<uint8_t>(subjectSlot));
     emitBytes(Op::CALL, 1);
-    emitBytes(Op::CONSTANT,
-              makeConstant(Value{static_cast<double>(fixedCount)}));
+    emitConstantOp(Op::CONSTANT,
+                   makeConstant(Value{static_cast<double>(fixedCount)}));
     if (hasRest) {
         // rest pattern: miss when len < fixedCount.
         // LESS pushes (len < fixedCount): true=miss. NOT inverts: false=miss.
@@ -1803,9 +1811,9 @@ Compiler::ListPatResult Compiler::compileListPattern(int subjectSlot,
             if (std::string(elem.name.lexeme) != "_") {
                 // subject[fixedCount : len(subject)]
                 emitBytes(Op::GET_LOCAL, static_cast<uint8_t>(subjectSlot));
-                emitBytes(Op::CONSTANT,
-                          makeConstant(Value{static_cast<double>(fixedCount)}));
-                emitBytes(Op::GET_GLOBAL, identifierConstant(lenTok));
+                emitConstantOp(Op::CONSTANT,
+                               makeConstant(Value{static_cast<double>(fixedCount)}));
+                emitConstantOp(Op::GET_GLOBAL, identifierConstant(lenTok));
                 emitBytes(Op::GET_LOCAL, static_cast<uint8_t>(subjectSlot));
                 emitBytes(Op::CALL, 1);
                 emitByte(Op::SLICE);
@@ -1816,8 +1824,8 @@ Compiler::ListPatResult Compiler::compileListPattern(int subjectSlot,
             }
         } else {
             emitBytes(Op::GET_LOCAL, static_cast<uint8_t>(subjectSlot));
-            emitBytes(Op::CONSTANT,
-                      makeConstant(Value{static_cast<double>(i)}));
+            emitConstantOp(Op::CONSTANT,
+                           makeConstant(Value{static_cast<double>(i)}));
             emitByte(Op::GET_INDEX);
             if (std::string(elem.name.lexeme) == "_") {
                 emitByte(Op::POP);

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -138,8 +138,9 @@ class Compiler {
     void emitLoop(int loopStart);
     void emitLoopCleanup(int targetLocalCount);
 
-    uint8_t makeConstant(Value value);
-    uint8_t identifierConstant(const Token& name);
+    uint16_t makeConstant(Value value);
+    uint16_t identifierConstant(const Token& name);
+    void emitConstantOp(Op op, uint16_t idx);
     void namedVariable(const Token& name, bool canAssign);
 
     // Walks the enclosing chain to the root compiler.

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -27,8 +27,8 @@ static int simpleInstruction(const char* name, int offset, std::ostream& out,
 static int constantInstruction(const char* name, const Chunk& chunk,
                                const MemoryManager& mm, int offset,
                                std::ostream& out, bool color) {
-    uint16_t idx = static_cast<uint16_t>(chunk.at(offset + 1) << 8 |
-                                         chunk.at(offset + 2));
+    uint16_t idx =
+        static_cast<uint16_t>(chunk.at(offset + 1) << 8 | chunk.at(offset + 2));
     out << cc(color, kBold) << name << cc(color, kReset) << ' '
         << static_cast<int>(idx) << " ('" << cc(color, kYellow)
         << stringify(chunk.getConstant(idx)) << cc(color, kReset) << "')\n";
@@ -56,8 +56,8 @@ static int jumpInstruction(const char* name, int sign, const Chunk& chunk,
 static int invokeInstruction(const char* name, const Chunk& chunk,
                              const MemoryManager& mm, int offset,
                              std::ostream& out, bool color) {
-    uint16_t nameIdx = static_cast<uint16_t>(chunk.at(offset + 1) << 8 |
-                                              chunk.at(offset + 2));
+    uint16_t nameIdx =
+        static_cast<uint16_t>(chunk.at(offset + 1) << 8 | chunk.at(offset + 2));
     uint8_t argCount = chunk.at(offset + 3);
     out << cc(color, kBold) << name << cc(color, kReset) << ' '
         << static_cast<int>(nameIdx) << " ('" << cc(color, kYellow)
@@ -68,8 +68,8 @@ static int invokeInstruction(const char* name, const Chunk& chunk,
 
 static int closureInstruction(const char* name, const Chunk& chunk, int offset,
                               std::ostream& out, bool color) {
-    uint16_t idx = static_cast<uint16_t>(chunk.at(offset + 1) << 8 |
-                                         chunk.at(offset + 2));
+    uint16_t idx =
+        static_cast<uint16_t>(chunk.at(offset + 1) << 8 | chunk.at(offset + 2));
     Value fnVal = chunk.getConstant(idx);
     ObjFunction* fn = asObjFunction(fnVal);
     out << cc(color, kBold) << name << cc(color, kReset) << ' '

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -27,11 +27,12 @@ static int simpleInstruction(const char* name, int offset, std::ostream& out,
 static int constantInstruction(const char* name, const Chunk& chunk,
                                const MemoryManager& mm, int offset,
                                std::ostream& out, bool color) {
-    uint8_t idx = chunk.at(offset + 1);
+    uint16_t idx = static_cast<uint16_t>(chunk.at(offset + 1) << 8 |
+                                         chunk.at(offset + 2));
     out << cc(color, kBold) << name << cc(color, kReset) << ' '
         << static_cast<int>(idx) << " ('" << cc(color, kYellow)
         << stringify(chunk.getConstant(idx)) << cc(color, kReset) << "')\n";
-    return offset + 2;
+    return offset + 3;
 }
 
 static int byteInstruction(const char* name, const Chunk& chunk, int offset,
@@ -55,24 +56,26 @@ static int jumpInstruction(const char* name, int sign, const Chunk& chunk,
 static int invokeInstruction(const char* name, const Chunk& chunk,
                              const MemoryManager& mm, int offset,
                              std::ostream& out, bool color) {
-    uint8_t nameIdx = chunk.at(offset + 1);
-    uint8_t argCount = chunk.at(offset + 2);
+    uint16_t nameIdx = static_cast<uint16_t>(chunk.at(offset + 1) << 8 |
+                                              chunk.at(offset + 2));
+    uint8_t argCount = chunk.at(offset + 3);
     out << cc(color, kBold) << name << cc(color, kReset) << ' '
         << static_cast<int>(nameIdx) << " ('" << cc(color, kYellow)
         << stringify(chunk.getConstant(nameIdx)) << cc(color, kReset) << "') "
         << static_cast<int>(argCount) << '\n';
-    return offset + 3;
+    return offset + 4;
 }
 
 static int closureInstruction(const char* name, const Chunk& chunk, int offset,
                               std::ostream& out, bool color) {
-    uint8_t idx = chunk.at(offset + 1);
+    uint16_t idx = static_cast<uint16_t>(chunk.at(offset + 1) << 8 |
+                                         chunk.at(offset + 2));
     Value fnVal = chunk.getConstant(idx);
     ObjFunction* fn = asObjFunction(fnVal);
     out << cc(color, kBold) << name << cc(color, kReset) << ' '
         << static_cast<int>(idx) << " ('" << cc(color, kYellow)
         << stringify(fnVal) << cc(color, kReset) << "')\n";
-    offset += 2;
+    offset += 3;
     for (int i = 0; i < fn->upvalueCount; i++) {
         uint8_t isLocal = chunk.at(offset++);
         uint8_t index = chunk.at(offset++);

--- a/src/memory_manager.cpp
+++ b/src/memory_manager.cpp
@@ -154,7 +154,7 @@ void MemoryManager::traceObject(Obj* obj) {
         auto* fn = static_cast<ObjFunction*>(obj);
         markObject(fn->name);
         const auto& consts = fn->chunk.constants();
-        for (uint8_t i = 0; i < consts.size(); i++)
+        for (uint16_t i = 0; i < consts.size(); i++)
             markValue(consts.at(i));
         break;
     }

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -50,9 +50,9 @@ void printValue(const Value& value) {
     std::printf("%s", stringify(value).c_str());
 }
 
-uint8_t ValueArray::size() const { return m_count; }
+uint16_t ValueArray::size() const { return m_count; }
 
-void ValueArray::write(Value value) { at(m_count++) = value; }
+void ValueArray::write(Value value) { m_values.push_back(value); m_count++; }
 
 uint32_t hashValue(const Value& v) {
     return std::visit(

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -52,7 +52,10 @@ void printValue(const Value& value) {
 
 uint16_t ValueArray::size() const { return m_count; }
 
-void ValueArray::write(Value value) { m_values.push_back(value); m_count++; }
+void ValueArray::write(Value value) {
+    m_values.push_back(value);
+    m_count++;
+}
 
 uint32_t hashValue(const Value& v) {
     return std::visit(

--- a/src/value.h
+++ b/src/value.h
@@ -2,9 +2,9 @@
 
 #include "object.h"
 
-#include <array>
 #include <cstdint>
 #include <variant>
+#include <vector>
 
 using Number = double;
 using Nil = std::monostate;
@@ -54,13 +54,14 @@ bool isValidMapKey(const Value& v);
 
 inline bool isFalsy(const Value& v) { return !v; }
 
-class ValueArray : std::array<Value, UINT8_MAX> {
+class ValueArray {
   public:
-    using std::array<Value, UINT8_MAX>::at;
     void write(Value value);
-    uint8_t size() const;
-    bool isFull() const { return m_count >= UINT8_MAX; }
+    uint16_t size() const;
+    bool isFull() const { return m_count >= UINT16_MAX; }
+    Value at(uint16_t idx) const { return m_values.at(idx); }
 
   private:
-    uint8_t m_count = 0;
+    std::vector<Value> m_values;
+    uint16_t m_count = 0;
 };

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -372,7 +372,7 @@ uint16_t VM::readShort() {
 
 Value VM::readConstant() {
     return m_frames[m_frameCount - 1].closure->function->chunk.getConstant(
-        readByte());
+        readShort());
 }
 
 Value VM::lastResult() const { return m_lastResult; }

--- a/test/test_parser_bytecode.cpp
+++ b/test/test_parser_bytecode.cpp
@@ -22,12 +22,13 @@ class ParserBytecodeTest : public ::testing::Test {};
 TEST_F(ParserBytecodeTest, Arithmetic_Addition) {
     std::string expr = "1 + 2";
     std::string bytecode = compile_to_bytecode(expr);
+    // CONSTANT now takes 3 bytes (opcode + 2-byte index).
     std::string expected = "0: CONSTANT 0 ('1')\n"
-                           "2: CONSTANT 1 ('2')\n"
-                           "4: ADD\n"
-                           "5: POP\n"
-                           "6: NIL\n"
-                           "7: RETURN\n";
+                           "3: CONSTANT 1 ('2')\n"
+                           "6: ADD\n"
+                           "7: POP\n"
+                           "8: NIL\n"
+                           "9: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -35,13 +36,13 @@ TEST_F(ParserBytecodeTest, Arithmetic_MultiplySubtract) {
     std::string expr = "3 * 4 - 5";
     std::string bytecode = compile_to_bytecode(expr);
     std::string expected = "0: CONSTANT 0 ('3')\n"
-                           "2: CONSTANT 1 ('4')\n"
-                           "4: MULTIPLY\n"
-                           "5: CONSTANT 2 ('5')\n"
-                           "7: SUBTRACT\n"
-                           "8: POP\n"
-                           "9: NIL\n"
-                           "10: RETURN\n";
+                           "3: CONSTANT 1 ('4')\n"
+                           "6: MULTIPLY\n"
+                           "7: CONSTANT 2 ('5')\n"
+                           "10: SUBTRACT\n"
+                           "11: POP\n"
+                           "12: NIL\n"
+                           "13: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -50,11 +51,11 @@ TEST_F(ParserBytecodeTest, Comparison_Equal) {
     std::string bytecode = compile_to_bytecode(expr);
     // After constant-pool deduplication both '1' literals share slot 0.
     std::string expected = "0: CONSTANT 0 ('1')\n"
-                           "2: CONSTANT 0 ('1')\n"
-                           "4: EQUAL\n"
-                           "5: POP\n"
-                           "6: NIL\n"
-                           "7: RETURN\n";
+                           "3: CONSTANT 0 ('1')\n"
+                           "6: EQUAL\n"
+                           "7: POP\n"
+                           "8: NIL\n"
+                           "9: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -62,13 +63,13 @@ TEST_F(ParserBytecodeTest, Comparison_LessGreater) {
     std::string expr = "2 < 3 > 1";
     std::string bytecode = compile_to_bytecode(expr);
     std::string expected = "0: CONSTANT 0 ('2')\n"
-                           "2: CONSTANT 1 ('3')\n"
-                           "4: LESS\n"
-                           "5: CONSTANT 2 ('1')\n"
-                           "7: GREATER\n"
-                           "8: POP\n"
-                           "9: NIL\n"
-                           "10: RETURN\n";
+                           "3: CONSTANT 1 ('3')\n"
+                           "6: LESS\n"
+                           "7: CONSTANT 2 ('1')\n"
+                           "10: GREATER\n"
+                           "11: POP\n"
+                           "12: NIL\n"
+                           "13: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -89,11 +90,11 @@ TEST_F(ParserBytecodeTest, String_Concatenation) {
     std::string expr = "\"foo\" + \"bar\"";
     std::string bytecode = compile_to_bytecode(expr);
     std::string expected = "0: CONSTANT 0 ('foo')\n"
-                           "2: CONSTANT 1 ('bar')\n"
-                           "4: ADD\n"
-                           "5: POP\n"
-                           "6: NIL\n"
-                           "7: RETURN\n";
+                           "3: CONSTANT 1 ('bar')\n"
+                           "6: ADD\n"
+                           "7: POP\n"
+                           "8: NIL\n"
+                           "9: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -101,12 +102,12 @@ TEST_F(ParserBytecodeTest, GroupingAndNegate) {
     std::string expr = "-(1 + 2)";
     std::string bytecode = compile_to_bytecode(expr);
     std::string expected = "0: CONSTANT 0 ('1')\n"
-                           "2: CONSTANT 1 ('2')\n"
-                           "4: ADD\n"
-                           "5: NEGATE\n"
-                           "6: POP\n"
-                           "7: NIL\n"
-                           "8: RETURN\n";
+                           "3: CONSTANT 1 ('2')\n"
+                           "6: ADD\n"
+                           "7: NEGATE\n"
+                           "8: POP\n"
+                           "9: NIL\n"
+                           "10: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -134,15 +135,15 @@ TEST_F(ParserBytecodeTest, Dedup_SameVariableReusesConstantSlot) {
     std::string src = "var x = 1;\n"
                       "x = x + 1;";
     std::string bytecode = compile_program_to_bytecode(src);
-    std::string expected = "0: CONSTANT 0 ('1')\n" // initializer: 1 → slot 0
-                           "2: DEFINE_GLOBAL 1 ('x')\n" // x → slot 1
-                           "4: GET_GLOBAL 1 ('x')\n"    // x reuses slot 1
-                           "6: CONSTANT 0 ('1')\n"      // 1 reuses slot 0
-                           "8: ADD\n"
-                           "9: SET_GLOBAL 1 ('x')\n" // x reuses slot 1
-                           "11: POP\n"
-                           "12: NIL\n"
-                           "13: RETURN\n";
+    std::string expected = "0: CONSTANT 0 ('1')\n"  // initializer: 1 → slot 0
+                           "3: DEFINE_GLOBAL 1 ('x')\n" // x → slot 1
+                           "6: GET_GLOBAL 1 ('x')\n"    // x reuses slot 1
+                           "9: CONSTANT 0 ('1')\n"      // 1 reuses slot 0
+                           "12: ADD\n"
+                           "13: SET_GLOBAL 1 ('x')\n" // x reuses slot 1
+                           "16: POP\n"
+                           "17: NIL\n"
+                           "18: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -159,9 +160,9 @@ TEST_F(FunctionBytecodeTest, EmptyFunction_OuterChunk) {
     // Constant 0 = 'foo' (global name), constant 1 = <fn foo>
     std::string bytecode = compile_program_to_bytecode("fun foo() {}");
     std::string expected = "0: CLOSURE 1 ('<fn foo>')\n"
-                           "2: DEFINE_GLOBAL 0 ('foo')\n"
-                           "4: NIL\n"
-                           "5: RETURN\n";
+                           "3: DEFINE_GLOBAL 0 ('foo')\n"
+                           "6: NIL\n"
+                           "7: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -205,8 +206,8 @@ TEST_F(FunctionBytecodeTest, FunctionWithLocalVar_InnerChunk) {
     std::string src = "fun noReturn() { var x = 1; }";
     std::string bytecode = compile_fn_body_to_bytecode(src);
     std::string expected = "0: CONSTANT 0 ('1')\n"
-                           "2: NIL\n"
-                           "3: RETURN\n";
+                           "3: NIL\n"
+                           "4: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -214,11 +215,11 @@ TEST_F(ParserBytecodeTest, Arithmetic_Modulo) {
     std::string expr = "10 % 3";
     std::string bytecode = compile_to_bytecode(expr);
     std::string expected = "0: CONSTANT 0 ('10')\n"
-                           "2: CONSTANT 1 ('3')\n"
-                           "4: MODULO\n"
-                           "5: POP\n"
-                           "6: NIL\n"
-                           "7: RETURN\n";
+                           "3: CONSTANT 1 ('3')\n"
+                           "6: MODULO\n"
+                           "7: POP\n"
+                           "8: NIL\n"
+                           "9: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -236,14 +237,14 @@ class SequenceBytecodeTest : public ::testing::Test {};
 TEST_F(SequenceBytecodeTest, InExpr_ListMembership) {
     std::string bytecode = compile_to_bytecode("2 in [1, 2, 3]");
     std::string expected = "0: CONSTANT 0 ('2')\n"
-                           "2: CONSTANT 1 ('1')\n"
-                           "4: CONSTANT 0 ('2')\n" // dedup: reuses slot 0
-                           "6: CONSTANT 2 ('3')\n"
-                           "8: BUILD_LIST 3\n"
-                           "10: IN\n"
-                           "11: POP\n"
-                           "12: NIL\n"
-                           "13: RETURN\n";
+                           "3: CONSTANT 1 ('1')\n"
+                           "6: CONSTANT 0 ('2')\n" // dedup: reuses slot 0
+                           "9: CONSTANT 2 ('3')\n"
+                           "12: BUILD_LIST 3\n"
+                           "14: IN\n"
+                           "15: POP\n"
+                           "16: NIL\n"
+                           "17: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -251,11 +252,11 @@ TEST_F(SequenceBytecodeTest, InExpr_ListMembership) {
 TEST_F(SequenceBytecodeTest, InExpr_StringSubstring) {
     std::string bytecode = compile_to_bytecode("\"ell\" in \"hello\"");
     std::string expected = "0: CONSTANT 0 ('ell')\n"
-                           "2: CONSTANT 1 ('hello')\n"
-                           "4: IN\n"
-                           "5: POP\n"
-                           "6: NIL\n"
-                           "7: RETURN\n";
+                           "3: CONSTANT 1 ('hello')\n"
+                           "6: IN\n"
+                           "7: POP\n"
+                           "8: NIL\n"
+                           "9: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 
@@ -267,28 +268,28 @@ TEST_F(SequenceBytecodeTest, InExpr_StringSubstring) {
 // GET_ITER replaces the list on the stack with an ObjIterator in-place.
 // Each loop iteration: GET_LOCAL 1 (iter copy) → ITER_HAS_NEXT → bool check,
 // then GET_LOCAL 1 (iter copy) → ITER_NEXT → element → SET_LOCAL 2.
-// continue re-enters at loopStart (offset 6), which re-checks ITER_HAS_NEXT.
+// continue re-enters at loopStart (offset 7), which re-checks ITER_HAS_NEXT.
 TEST_F(SequenceBytecodeTest, ForIn_EmptyBodyBytecode) {
     std::string bytecode = compile_program_to_bytecode("for (var x in [1]) {}");
     std::string expected =
-        "0: CONSTANT 0 ('1')\n" // list element
-        "2: BUILD_LIST 1\n"     // push [1]
-        "4: GET_ITER\n"    // replace [1] with ObjIterator → (iter) at slot 1
-        "5: NIL\n"         // push nil → x at slot 2
-        "6: GET_LOCAL 1\n" // loopStart: push (iter) copy
-        "8: ITER_HAS_NEXT\n" // pop copy, push bool
-        "9: JUMP_IF_FALSE 9 -> 22\n"
-        "12: POP\n"         // discard true
-        "13: GET_LOCAL 1\n" // push (iter) copy
-        "15: ITER_NEXT\n"   // pop copy, push next element + advance cursor
-        "16: SET_LOCAL 2\n" // x = element
-        "18: POP\n"
-        "19: LOOP 19 -> 6\n" // back to loopStart
-        "22: POP\n"          // discard false
-        "23: POP\n"          // endScope: x
-        "24: POP\n"          // endScope: (iter)
-        "25: NIL\n"
-        "26: RETURN\n";
+        "0: CONSTANT 0 ('1')\n" // list element (3 bytes)
+        "3: BUILD_LIST 1\n"     // push [1]
+        "5: GET_ITER\n"    // replace [1] with ObjIterator → (iter) at slot 1
+        "6: NIL\n"         // push nil → x at slot 2
+        "7: GET_LOCAL 1\n" // loopStart: push (iter) copy
+        "9: ITER_HAS_NEXT\n" // pop copy, push bool
+        "10: JUMP_IF_FALSE 10 -> 23\n"
+        "13: POP\n"         // discard true
+        "14: GET_LOCAL 1\n" // push (iter) copy
+        "16: ITER_NEXT\n"   // pop copy, push next element + advance cursor
+        "17: SET_LOCAL 2\n" // x = element
+        "19: POP\n"
+        "20: LOOP 20 -> 7\n" // back to loopStart
+        "23: POP\n"          // discard false
+        "24: POP\n"          // endScope: x
+        "25: POP\n"          // endScope: (iter)
+        "26: NIL\n"
+        "27: RETURN\n";
     EXPECT_EQ(trim(bytecode), trim(expected));
 }
 

--- a/test/test_parser_bytecode.cpp
+++ b/test/test_parser_bytecode.cpp
@@ -135,7 +135,7 @@ TEST_F(ParserBytecodeTest, Dedup_SameVariableReusesConstantSlot) {
     std::string src = "var x = 1;\n"
                       "x = x + 1;";
     std::string bytecode = compile_program_to_bytecode(src);
-    std::string expected = "0: CONSTANT 0 ('1')\n"  // initializer: 1 → slot 0
+    std::string expected = "0: CONSTANT 0 ('1')\n" // initializer: 1 → slot 0
                            "3: DEFINE_GLOBAL 1 ('x')\n" // x → slot 1
                            "6: GET_GLOBAL 1 ('x')\n"    // x reuses slot 1
                            "9: CONSTANT 0 ('1')\n"      // 1 reuses slot 0

--- a/test/test_vm_runtime.cpp
+++ b/test/test_vm_runtime.cpp
@@ -261,14 +261,24 @@ TEST_F(CompileErrorTest, InvalidAssignmentTarget) {
 }
 
 TEST_F(CompileErrorTest, TooManyConstants) {
-    // Generate 256 distinct numeric literal expression statements.
-    // The 256th constant exhausts the pool (capacity: 255) and must produce a
-    // compile error — not a crash or out-of-bounds exception.
+    // Generate 65536 distinct numeric literal expression statements.
+    // The 65536th constant exhausts the pool (capacity: 65535) and must produce
+    // a compile error — not a crash or out-of-bounds exception.
     std::string source;
-    for (int i = 0; i < 256; ++i)
-        source += std::to_string(i) + ";\n";
+    for (int i = 0; i < 65536; ++i)
+        source += std::to_string(i) + ".5;\n"; // .5 avoids integer dedup
     VMTestHarness h;
     EXPECT_EQ(h.run(source), InterpretResult::COMPILE_ERROR);
+}
+
+TEST_F(CompileErrorTest, MoreThan255ConstantsSucceed) {
+    // Programs with more than 255 distinct constants must compile and run.
+    std::string source;
+    for (int i = 0; i < 300; ++i)
+        source += "var v" + std::to_string(i) + " = " + std::to_string(i) +
+                  ".5;\n";
+    VMTestHarness h;
+    EXPECT_EQ(h.run(source), InterpretResult::OK);
 }
 
 // ===========================================================================

--- a/test/test_vm_runtime.cpp
+++ b/test/test_vm_runtime.cpp
@@ -275,8 +275,8 @@ TEST_F(CompileErrorTest, MoreThan255ConstantsSucceed) {
     // Programs with more than 255 distinct constants must compile and run.
     std::string source;
     for (int i = 0; i < 300; ++i)
-        source += "var v" + std::to_string(i) + " = " + std::to_string(i) +
-                  ".5;\n";
+        source +=
+            "var v" + std::to_string(i) + " = " + std::to_string(i) + ".5;\n";
     VMTestHarness h;
     EXPECT_EQ(h.run(source), InterpretResult::OK);
 }


### PR DESCRIPTION
## Summary

- All constant-bearing opcodes now use a **2-byte big-endian operand** for the constant pool index, raising the per-chunk limit from 255 to **65 535**
- `ValueArray` is now backed by `std::vector<Value>` instead of a fixed `std::array<Value, UINT8_MAX>`, eliminating the static cap
- `Chunk::addConstant` / `getConstant` use `uint16_t`; compiler helpers `makeConstant`, `identifierConstant`, and the new `emitConstantOp` all carry 16-bit indices
- `VM::readConstant()` now calls `readShort()` (which already existed for jumps) — no new VM machinery required
- Disassembler updated: `constantInstruction`, `invokeInstruction`, `closureInstruction` all read 2 bytes for the pool index
- **GC correctness fix**: `memory_manager.cpp` constant-marking loop used `uint8_t i`, which would silently wrap and miss constants at indices ≥ 256

## Test plan

- [ ] All 29 existing tests pass (`ctest`)
- [ ] `TooManyConstants` threshold updated to 65 536 — still triggers `COMPILE_ERROR`
- [ ] New `MoreThan255ConstantsSucceed` test: 300 distinct globals compile and run correctly
- [ ] Manual smoke test: `v299 = 299.5` reads back correctly in a 300-variable script

🤖 Generated with [Claude Code](https://claude.com/claude-code)