### PR TITLE
feat: add benchmark suite (7 benchmarks + runner)

### DIFF
--- a/benchmarks/binary_trees.lox
+++ b/benchmarks/binary_trees.lox
@@ -1,0 +1,57 @@
+// Binary trees — stresses GC and object allocation.
+// Port of Computer Language Benchmarks Game binary-trees.
+// Allocates a complete binary tree of given depth, then checks (sums) all nodes.
+
+class Tree {
+    init(left, right) {
+        this.left = left;
+        this.right = right;
+    }
+
+    check() {
+        if (this.left == nil) return 1;
+        return 1 + this.left.check() + this.right.check();
+    }
+}
+
+fun make(depth) {
+    if (depth == 0) return Tree(nil, nil);
+    depth = depth - 1;
+    return Tree(make(depth), make(depth));
+}
+
+var MIN_DEPTH = 4;
+var MAX_DEPTH = 12;
+
+var start = clock();
+
+// Stretch tree: allocate and immediately discard one tree of max_depth+2.
+var stretch_depth = MAX_DEPTH + 2;
+var check = make(stretch_depth).check();
+
+// Long-lived tree that survives all iterations.
+var long_lived = make(MAX_DEPTH);
+
+var total_checks = 0;
+var depth = MIN_DEPTH;
+while (depth <= MAX_DEPTH) {
+    var iterations = 1;
+    var d = MAX_DEPTH - depth + MIN_DEPTH;
+    while (d > 0) {
+        iterations = iterations * 2;
+        d = d - 1;
+    }
+    var i = 0;
+    while (i < iterations) {
+        total_checks = total_checks + make(depth).check();
+        i = i + 1;
+    }
+    depth = depth + 2;
+}
+
+// Verify long-lived tree is intact.
+var alive = long_lived.check();
+
+// Result: 1 if long-lived tree check > 0 (sanity).
+print "result: " + str(alive > 0);
+print "elapsed: " + str(clock() - start);

--- a/benchmarks/fib.lox
+++ b/benchmarks/fib.lox
@@ -1,0 +1,12 @@
+// Naive recursive Fibonacci — stresses function call overhead.
+// Source: Wren benchmarks / Are We Fast Yet?
+
+fun fib(n) {
+    if (n < 2) return n;
+    return fib(n - 1) + fib(n - 2);
+}
+
+var start = clock();
+fib(35);
+print "result: " + str(fib(10));
+print "elapsed: " + str(clock() - start);

--- a/benchmarks/mandelbrot.lox
+++ b/benchmarks/mandelbrot.lox
@@ -1,0 +1,32 @@
+// Mandelbrot — stresses float arithmetic in tight loops.
+// Counts pixels inside the Mandelbrot set for a 750x750 grid.
+// Port of AWFY / CLBG mandelbrot (output-free variant).
+
+var SIZE = 750;
+var LIMIT = 4.0;
+var ITERATIONS = 50;
+
+var start = clock();
+
+var inside = 0;
+for (var y = 0; y < SIZE; y = y + 1) {
+    for (var x = 0; x < SIZE; x = x + 1) {
+        var cr = 2.0 * x / SIZE - 1.5;
+        var ci = 2.0 * y / SIZE - 1.0;
+        var zr = 0.0;
+        var zi = 0.0;
+        var i = 0;
+        while (i < ITERATIONS) {
+            var zr2 = zr * zr;
+            var zi2 = zi * zi;
+            if (zr2 + zi2 > LIMIT) break;
+            zi = 2.0 * zr * zi + ci;
+            zr = zr2 - zi2 + cr;
+            i = i + 1;
+        }
+        if (i == ITERATIONS) inside = inside + 1;
+    }
+}
+
+print "result: " + str(inside > 0);
+print "elapsed: " + str(clock() - start);

--- a/benchmarks/method_call.lox
+++ b/benchmarks/method_call.lox
@@ -1,0 +1,52 @@
+// Method call / dynamic dispatch — stresses polymorphic dispatch.
+// Port of Wren's method_call benchmark.
+// Alternates between two subclasses via a Toggle object.
+
+class Toggle {
+    init(start) {
+        this.state = start;
+    }
+    value() {
+        return this.state;
+    }
+    activate() {
+        this.state = !this.state;
+        return this;
+    }
+}
+
+class NthToggle < Toggle {
+    init(start, max_counter) {
+        super.init(start);
+        this.count_max = max_counter;
+        this.counter = 0;
+    }
+    activate() {
+        this.counter = this.counter + 1;
+        if (this.counter >= this.count_max) {
+            this.state = !this.state;
+            this.counter = 0;
+        }
+        return this;
+    }
+}
+
+var N = 3000000;
+var start = clock();
+
+var toggle = Toggle(true);
+var i = 0;
+while (i < N) {
+    toggle = toggle.activate();
+    i = i + 1;
+}
+
+var toggle2 = NthToggle(true, 3);
+i = 0;
+while (i < N) {
+    toggle2 = toggle2.activate();
+    i = i + 1;
+}
+
+print "result: " + str(toggle.value());
+print "elapsed: " + str(clock() - start);

--- a/benchmarks/nbody.lox
+++ b/benchmarks/nbody.lox
@@ -1,0 +1,142 @@
+// N-body simulation — stresses float arithmetic and OOP method calls.
+// Port of Computer Language Benchmarks Game n-body (solar system, 5 bodies).
+
+var PI = 3.141592653589793;
+var SOLAR_MASS = 4 * PI * PI;
+var DAYS_PER_YEAR = 365.24;
+
+class Body {
+    init(x, y, z, vx, vy, vz, mass) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.vx = vx;
+        this.vy = vy;
+        this.vz = vz;
+        this.mass = mass;
+    }
+}
+
+fun sun() {
+    return Body(0, 0, 0, 0, 0, 0, SOLAR_MASS);
+}
+fun jupiter() {
+    return Body(
+        4.84143144246472090,
+        -1.16032004402742839,
+        -0.103622044471123109,
+        0.00166007664274403694 * DAYS_PER_YEAR,
+        0.00769901118419740425 * DAYS_PER_YEAR,
+        -0.0000690460016972063023 * DAYS_PER_YEAR,
+        0.000954791938424326609 * SOLAR_MASS
+    );
+}
+fun saturn() {
+    return Body(
+        8.34336671824457987,
+        4.12479856412430479,
+        -0.403523417114321381,
+        -0.00276742510726862411 * DAYS_PER_YEAR,
+        0.00499852801234917238 * DAYS_PER_YEAR,
+        0.0000230417297573763929 * DAYS_PER_YEAR,
+        0.000285885980666130812 * SOLAR_MASS
+    );
+}
+fun uranus() {
+    return Body(
+        12.8943695621391310,
+        -15.1111514016986312,
+        -0.223307578892655734,
+        0.00296460137564761618 * DAYS_PER_YEAR,
+        0.00237847173959480950 * DAYS_PER_YEAR,
+        -0.0000296589568540237556 * DAYS_PER_YEAR,
+        0.0000436624404335156298 * SOLAR_MASS
+    );
+}
+fun neptune() {
+    return Body(
+        15.3796971148509165,
+        -25.9193146099879641,
+        0.179258772950371181,
+        0.00268067772490389322 * DAYS_PER_YEAR,
+        0.00162824170038242295 * DAYS_PER_YEAR,
+        -0.0000951592254519715870 * DAYS_PER_YEAR,
+        0.0000515138902046611451 * SOLAR_MASS
+    );
+}
+
+fun offset_momentum(bodies) {
+    var px = 0;
+    var py = 0;
+    var pz = 0;
+    for (var b in bodies) {
+        px = px + b.vx * b.mass;
+        py = py + b.vy * b.mass;
+        pz = pz + b.vz * b.mass;
+    }
+    var sun = bodies[0];
+    sun.vx = -px / SOLAR_MASS;
+    sun.vy = -py / SOLAR_MASS;
+    sun.vz = -pz / SOLAR_MASS;
+}
+
+fun advance(bodies, dt) {
+    var n = len(bodies);
+    for (var i = 0; i < n; i = i + 1) {
+        var bi = bodies[i];
+        for (var j = i + 1; j < n; j = j + 1) {
+            var bj = bodies[j];
+            var dx = bi.x - bj.x;
+            var dy = bi.y - bj.y;
+            var dz = bi.z - bj.z;
+            var dist2 = dx * dx + dy * dy + dz * dz;
+            var mag = dt / (dist2 * math.sqrt(dist2));
+            bi.vx = bi.vx - dx * bj.mass * mag;
+            bi.vy = bi.vy - dy * bj.mass * mag;
+            bi.vz = bi.vz - dz * bj.mass * mag;
+            bj.vx = bj.vx + dx * bi.mass * mag;
+            bj.vy = bj.vy + dy * bi.mass * mag;
+            bj.vz = bj.vz + dz * bi.mass * mag;
+        }
+    }
+    for (var b in bodies) {
+        b.x = b.x + dt * b.vx;
+        b.y = b.y + dt * b.vy;
+        b.z = b.z + dt * b.vz;
+    }
+}
+
+fun energy(bodies) {
+    var e = 0;
+    var n = len(bodies);
+    for (var i = 0; i < n; i = i + 1) {
+        var bi = bodies[i];
+        e = e + 0.5 * bi.mass * (bi.vx * bi.vx + bi.vy * bi.vy + bi.vz * bi.vz);
+        for (var j = i + 1; j < n; j = j + 1) {
+            var bj = bodies[j];
+            var dx = bi.x - bj.x;
+            var dy = bi.y - bj.y;
+            var dz = bi.z - bj.z;
+            var dist = math.sqrt(dx * dx + dy * dy + dz * dz);
+            e = e - bi.mass * bj.mass / dist;
+        }
+    }
+    return e;
+}
+
+var bodies = [sun(), jupiter(), saturn(), uranus(), neptune()];
+offset_momentum(bodies);
+
+var N = 200000;
+var start = clock();
+
+var i = 0;
+while (i < N) {
+    advance(bodies, 0.01);
+    i = i + 1;
+}
+
+var e = energy(bodies);
+
+print "result: " + str(e < -0.1);
+print "elapsed: " + str(clock() - start);

--- a/benchmarks/sieve.lox
+++ b/benchmarks/sieve.lox
@@ -1,0 +1,38 @@
+// Sieve of Eratosthenes — stresses list (array) access and loops.
+// Source: Are We Fast Yet? benchmark suite.
+
+fun sieve(limit) {
+    var primes = [];
+    var i = 0;
+    while (i <= limit) {
+        primes.append(true);
+        i = i + 1;
+    }
+    primes[0] = false;
+    primes[1] = false;
+
+    i = 2;
+    while (i * i <= limit) {
+        if (primes[i]) {
+            var j = i * i;
+            while (j <= limit) {
+                primes[j] = false;
+                j = j + i;
+            }
+        }
+        i = i + 1;
+    }
+
+    var count = 0;
+    i = 0;
+    while (i <= limit) {
+        if (primes[i]) count = count + 1;
+        i = i + 1;
+    }
+    return count;
+}
+
+var start = clock();
+var r = sieve(2000000);
+print "result: " + str(r);
+print "elapsed: " + str(clock() - start);

--- a/benchmarks/towers.lox
+++ b/benchmarks/towers.lox
@@ -1,0 +1,37 @@
+// Towers of Hanoi — stresses recursion and list (stack) operations.
+// Source: Are We Fast Yet? benchmark suite.
+// Counts total moves for 22 discs (should be 2^22 - 1 = 4194303).
+
+var DISCS = 22;
+
+fun run_towers() {
+    var piles = [[], [], []];
+    var move_count = 0;
+
+    fun move(n, from, to, via) {
+        if (n == 1) {
+            piles[to].append(piles[from].pop());
+            move_count = move_count + 1;
+        } else {
+            move(n - 1, from, via, to);
+            piles[to].append(piles[from].pop());
+            move_count = move_count + 1;
+            move(n - 1, via, to, from);
+        }
+    }
+
+    var i = DISCS;
+    while (i >= 1) {
+        piles[0].append(i);
+        i = i - 1;
+    }
+
+    move(DISCS, 0, 2, 1);
+    return move_count;
+}
+
+var start = clock();
+var count = run_towers();
+// 2^22 - 1 = 4194303 moves expected
+print "result: " + str(count == 4194303);
+print "elapsed: " + str(clock() - start);

--- a/tools/run_benchmarks.py
+++ b/tools/run_benchmarks.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Lox++ benchmark runner.
+
+Runs each .lox file in the benchmarks/ directory, collects timing, and
+prints a summary table.
+
+Usage:
+  python3 tools/run_benchmarks.py [options]
+
+Options:
+  --interpreter PATH   Path to the Lox++ binary (default: build/loxpp)
+  --filter PATTERN     Only run benchmarks whose name contains PATTERN
+  --iterations N       Number of timed runs per benchmark (default: 5)
+  --json FILE          Write raw results to FILE as JSON
+"""
+
+import argparse
+import json
+import os
+import re
+import statistics
+import subprocess
+import sys
+import time
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BENCHMARKS_DIR = os.path.join(REPO_ROOT, "benchmarks")
+
+# Expected results for correctness verification. Key = benchmark stem.
+EXPECTED_RESULTS = {
+    "fib":          "55",      # fib(10) = 55, stable checksum
+    "binary_trees": "true",    # long-lived tree check > 0
+    "nbody":        "true",    # energy < -0.1
+    "mandelbrot":   "true",    # nonzero pixel count
+    "method_call":  "true",    # toggle.value() after even number of flips
+    "sieve":        "148933",  # primes up to 2000000
+    "towers":       "true",    # move_count == 2^20 - 1
+}
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Lox++ benchmark runner")
+    p.add_argument("--interpreter", default=os.path.join(REPO_ROOT, "build", "loxpp"),
+                   help="Path to loxpp binary (default: build/loxpp)")
+    p.add_argument("--filter", default="", metavar="PATTERN",
+                   help="Only run benchmarks whose name contains PATTERN")
+    p.add_argument("--iterations", type=int, default=5, metavar="N",
+                   help="Timed runs per benchmark (default: 5)")
+    p.add_argument("--json", metavar="FILE",
+                   help="Write raw results to FILE as JSON")
+    return p.parse_args()
+
+
+def discover_benchmarks(filter_str):
+    files = sorted(
+        f for f in os.listdir(BENCHMARKS_DIR)
+        if f.endswith(".lox") and filter_str in f
+    )
+    return [os.path.join(BENCHMARKS_DIR, f) for f in files]
+
+
+def run_once(interpreter, benchmark_path):
+    """Run one benchmark and return (elapsed_s, result_str) or raise."""
+    wall_start = time.perf_counter()
+    try:
+        proc = subprocess.run(
+            [interpreter, benchmark_path],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        raise RuntimeError("timed out after 120 s")
+
+    wall_elapsed = time.perf_counter() - wall_start
+
+    if proc.returncode != 0:
+        raise RuntimeError(f"non-zero exit {proc.returncode}: {proc.stderr.strip()}")
+
+    elapsed = None
+    result = None
+    for line in proc.stdout.splitlines():
+        m = re.match(r"elapsed:\s*(.+)", line)
+        if m:
+            elapsed = float(m.group(1))
+        m = re.match(r"result:\s*(.+)", line)
+        if m:
+            result = m.group(1).strip()
+
+    if elapsed is None:
+        # Fall back to wall time if the benchmark doesn't print elapsed:
+        elapsed = wall_elapsed
+    if result is None:
+        result = "<no result>"
+
+    return elapsed, result
+
+
+def verify(name, result):
+    expected = EXPECTED_RESULTS.get(name)
+    if expected is None:
+        return True  # no expectation registered
+    return result.startswith(expected)
+
+
+def col(s, w, right=False):
+    s = str(s)
+    return s.rjust(w) if right else s.ljust(w)
+
+
+def main():
+    args = parse_args()
+
+    if not os.path.isfile(args.interpreter):
+        print(f"error: interpreter not found: {args.interpreter}", file=sys.stderr)
+        print("hint: run  cmake --preset release && cmake --build build", file=sys.stderr)
+        sys.exit(1)
+
+    benchmarks = discover_benchmarks(args.filter)
+    if not benchmarks:
+        print(f"No benchmarks found in {BENCHMARKS_DIR!r} (filter={args.filter!r})")
+        sys.exit(0)
+
+    print(f"Interpreter : {args.interpreter}")
+    print(f"Benchmarks  : {BENCHMARKS_DIR}")
+    print(f"Iterations  : {args.iterations}")
+    print()
+
+    all_results = {}
+    rows = []
+    any_fail = False
+
+    for path in benchmarks:
+        name = os.path.splitext(os.path.basename(path))[0]
+        timings = []
+        last_result = None
+        error = None
+
+        print(f"  {name} ...", end="", flush=True)
+        for i in range(args.iterations):
+            try:
+                elapsed, result = run_once(args.interpreter, path)
+                timings.append(elapsed)
+                last_result = result
+                print(".", end="", flush=True)
+            except RuntimeError as e:
+                error = str(e)
+                print("E", end="", flush=True)
+                break
+
+        print()
+
+        if error:
+            all_results[name] = {"error": error}
+            rows.append((name, "ERROR", "", "", error, False))
+            any_fail = True
+            continue
+
+        median = statistics.median(timings)
+        lo = min(timings)
+        hi = max(timings)
+        ok = verify(name, last_result)
+        if not ok:
+            any_fail = True
+
+        all_results[name] = {
+            "timings": timings,
+            "median": median,
+            "min": lo,
+            "max": hi,
+            "result": last_result,
+            "ok": ok,
+        }
+        rows.append((name, f"{median:.3f}", f"{lo:.3f}", f"{hi:.3f}", last_result, ok))
+
+    # Print table
+    print()
+    hdr = ("Benchmark", "Median (s)", "Min (s)", "Max (s)", "Result", "OK")
+    widths = (14, 10, 9, 9, 14, 4)
+    sep = "  ".join("-" * w for w in widths)
+    header = "  ".join(col(h, w) for h, w in zip(hdr, widths))
+    print(header)
+    print(sep)
+    for name, med, lo, hi, result, ok in rows:
+        ok_str = "OK" if ok else "FAIL"
+        print("  ".join(col(v, w, right=(i in (1, 2, 3)))
+                        for i, (v, w) in enumerate(zip(
+                            (name, med, lo, hi, result, ok_str), widths))))
+
+    if args.json:
+        with open(args.json, "w") as f:
+            json.dump(all_results, f, indent=2)
+        print(f"\nRaw results written to {args.json}")
+
+    if any_fail:
+        print("\nWARNING: one or more benchmarks failed correctness check.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `benchmarks/` directory with 7 portable Lox++ benchmarks ported from **Are We Fast Yet?**, **Computer Language Benchmarks Game**, and **Wren**'s benchmark suite
- Adds `tools/run_benchmarks.py` — a runner that times each benchmark, reports a median/min/max table, and verifies correctness against expected output

## Benchmarks

| File | Source | Stresses | Work size | ~Time |
|------|--------|----------|-----------|-------|
| `fib.lox` | Wren / AWFY | Recursion, call overhead | `fib(35)` | 0.9s |
| `binary_trees.lox` | CLBG / Wren | GC, object allocation | depth=12 | 3.6s |
| `nbody.lox` | CLBG / AWFY | Float arithmetic, OOP | 200k steps | 1.1s |
| `mandelbrot.lox` | AWFY / CLBG | Float loops | 750×750 grid | 1.2s |
| `method_call.lox` | Wren | Dynamic dispatch | 3M calls | 0.6s |
| `sieve.lox` | AWFY | List access, loops | primes ≤ 2M | 0.3s |
| `towers.lox` | AWFY | Recursion, list ops | 22 discs | 0.3s |

Each benchmark prints `result: <checksum>` and `elapsed: <seconds>` using `clock()`.

## Runner usage

```bash
# Build release binary first
cmake --preset release && cmake --build build

# Run all benchmarks (5 iterations, median reported)
python3 tools/run_benchmarks.py

# Filter to a subset
python3 tools/run_benchmarks.py --filter fib

# Compare two interpreters
python3 tools/run_benchmarks.py --interpreter build/loxpp
python3 tools/run_benchmarks.py --interpreter bootstrap/lox_wrapper.sh

# Save raw JSON
python3 tools/run_benchmarks.py --json results.json
```

## Sample output (release build, 3 iterations)

```
Benchmark       Median (s)  Min (s)    Max (s)    Result          OK
--------------  ----------  ---------  ---------  --------------  ----
binary_trees         3.383      3.338      3.566  true            OK
fib                  0.830      0.826      0.833  55              OK
mandelbrot           1.163      1.158      1.175  true            OK
method_call          0.633      0.631      0.642  true            OK
nbody                1.093      1.073      1.108  true            OK
sieve                0.276      0.274      0.294  148933          OK
towers               0.342      0.328      0.350  true            OK
```

## Notes

- No CI integration — benchmarks are informational only, not gated
- No CMakeLists changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)