### PR TITLE
docs(agents): prefer self-explanatory code over comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,3 +109,8 @@ fix: prevent double-free in ObjString destructor
 
 If you'd write "and" in the subject, split the commit. Add a body only when the
 *why* needs explaining.
+
+**Comments:** let the code and the project structure speak for themselves.
+Comment only the non-obvious *why* — a subtle invariant, a constraint not
+visible locally, a deliberate trade-off. Don't narrate *what* the code already
+states or restate the obvious; redundant comments are noise, not help.


### PR DESCRIPTION
## Summary

Adds a **Comments** convention to `AGENTS.md` → Conventions: let the code and
project structure speak for themselves; comment only the non-obvious *why* (a
subtle invariant, a constraint not visible locally, a deliberate trade-off),
never restate the obvious.

Split out of #89 (NaN-tagging) per review — it's a general dev-process
guideline, not part of that feature.

## Test plan

Docs-only; no build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)