### PR TITLE
perf: make constant-heavy compilation O(n); parallelize ctest per-case

### DIFF
--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -15,13 +15,8 @@ void Chunk::write(Op op, int line) { write(static_cast<Byte>(op), line); }
 void Chunk::patch(int offset, Byte byte) { (*this)[offset] = byte; }
 
 std::optional<uint16_t> Chunk::addConstant(Value value) {
-    // O(N) scan for an existing equal constant; avoids duplicate slots.
-    // Strings are interned, so ObjHandle equality (index+type) suffices.
-    for (uint16_t i = 0; i < m_constants.size(); i++) {
-        if (m_constants.at(i) == value) {
-            return i;
-        }
-    }
+    // Append-only: dedup is the compiler's job (Compiler::makeConstant keeps an
+    // O(1) hash index), so this stays a plain bounded push.
     if (m_constants.isFull()) {
         return std::nullopt;
     }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1799,11 +1799,15 @@ void Compiler::emitLoopCleanup(int targetLocalCount) {
 }
 
 uint16_t Compiler::makeConstant(Value value) {
+    if (auto it = m_constantIndex.find(value); it != m_constantIndex.end()) {
+        return it->second;
+    }
     auto constant = getCurrentChunk()->addConstant(value);
     if (!constant) {
         m_parser->error("Too many constants in one chunk.");
         return 0;
     }
+    m_constantIndex.emplace(value, *constant);
     return *constant;
 }
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -175,7 +175,11 @@ void Compiler::literal() {
 }
 
 void Compiler::number() {
-    double num = std::stod(m_parser->m_previous.lexeme.data(), nullptr);
+    // Construct a bounded std::string from the lexeme view: the view's data()
+    // is not NUL-terminated at the token's end (it points into the source), so
+    // passing it straight to std::stod would scan to the end of the whole
+    // source — O(source length) per literal, i.e. O(N^2) over a large program.
+    double num = std::stod(std::string(m_parser->m_previous.lexeme));
     emitConstantOp(Op::CONSTANT, makeConstant(from<Number>(num)));
 }
 

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -187,6 +187,11 @@ class Compiler {
     int m_upvalueCount{0};
     std::vector<LoopContext> m_loopStack;
 
+    // Constant-pool dedup index → existing slot, so repeated literals reuse one
+    // slot. O(1) amortized. Compile-time only: dies with this per-function
+    // Compiler and never reaches the runtime Chunk.
+    std::unordered_map<Value, uint16_t, ValueHash> m_constantIndex;
+
     // Constructor table — only meaningfully populated on the root compiler.
     std::unordered_map<std::string, ConstructorInfo> m_constructors;
     // enumName → ordered list of ctor names, for exhaustiveness checking.

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <cstdio>
 #include <cstring>
+#include <functional>
 
 bool operator!(Value value) {
     if (is<bool>(value)) {
@@ -87,4 +88,25 @@ bool isValidMapKey(const Value& v) {
         return as<Obj*>(v)->type == ObjType::STRING;
     }
     return true; // bool and nil are always valid
+}
+
+size_t ValueHash::operator()(const Value& v) const {
+    if (is<bool>(v)) {
+        return as<bool>(v) ? 1231U : 1237U;
+    }
+    if (is<Nil>(v)) {
+        return 0U;
+    }
+    if (is<Obj*>(v)) {
+        // Pointer identity — matches operator==. Do NOT use hashValue(), which
+        // assumes Obj* is an interned ObjString and is UB for other objects.
+        return std::hash<const void*>{}(as<Obj*>(v));
+    }
+    Number n = as<Number>(v);
+    if (n == 0.0) {
+        n = 0.0; // canonicalize -0.0 → +0.0 (matches -0.0 == 0.0)
+    }
+    uint64_t bits;
+    std::memcpy(&bits, &n, sizeof bits);
+    return std::hash<uint64_t>{}(bits);
 }

--- a/src/value.h
+++ b/src/value.h
@@ -168,6 +168,16 @@ uint32_t hashValue(const Value& v);
 // Returns false for NaN numbers and non-string objects.
 bool isValidMapKey(const Value& v);
 
+// General-purpose hash for any Value, consistent with operator==. Unlike
+// hashValue() (the table's uint32 string-key hash), this hashes Obj* by
+// pointer identity — matching operator== — so it is safe for any value,
+// including non-string objects. Used to dedup the compiler's constant pool.
+// Implemented via is<T>/as<T>, so it carries over to the NaN-tagged Value
+// representation unchanged.
+struct ValueHash {
+    size_t operator()(const Value& v) const;
+};
+
 inline bool isFalsy(const Value& v) { return !v; }
 
 class ValueArray {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(GTest REQUIRED)
+include(GoogleTest)
 
 # Propagate the NaN-tagging selection (inherited from the top-level option) to
 # every test target, which compile their own copies of src/*.cpp.
@@ -141,34 +142,21 @@ target_link_libraries(test_list_pattern_gc PRIVATE GTest::GTest GTest::Main)
 target_link_libraries(test_at_binding PRIVATE GTest::GTest GTest::Main)
 target_link_libraries(test_at_binding_gc PRIVATE GTest::GTest GTest::Main)
 
+# test_main is a hand-rolled main() (asserts), not a GTest binary.
 add_test(NAME TestMain COMMAND test_main)
-add_test(NAME TestScanner COMMAND test_scanner)
-add_test(NAME TestParserVM COMMAND test_parser_vm)
-add_test(NAME TestParserBytecode COMMAND test_parser_bytecode)
-add_test(NAME TestTable COMMAND test_table)
-add_test(NAME TestAllocator COMMAND test_allocator)
-add_test(NAME TestLocalVariables COMMAND test_local_variables)
-add_test(NAME TestControlFlow COMMAND test_control_flow)
-add_test(NAME TestVMRuntime COMMAND test_vm_runtime)
-add_test(NAME TestClosures COMMAND test_closures)
-add_test(NAME TestStressGC COMMAND test_stress_gc)
-add_test(NAME TestGcRegression COMMAND test_gc_regression)
-add_test(NAME TestInheritance COMMAND test_inheritance)
-add_test(NAME TestList COMMAND test_list)
-add_test(NAME TestListGC COMMAND test_list_gc)
-add_test(NAME TestMap COMMAND test_map)
-add_test(NAME TestMapGC COMMAND test_map_gc)
-add_test(NAME TestVarDestructure COMMAND test_var_destructure)
-add_test(NAME TestEnum COMMAND test_enum)
-add_test(NAME TestEnumGC COMMAND test_enum_gc)
-add_test(NAME TestClassPattern COMMAND test_class_pattern)
-add_test(NAME TestClassPatternGC COMMAND test_class_pattern_gc)
-add_test(NAME TestMatchExpr COMMAND test_match_expr)
-add_test(NAME TestSlice COMMAND test_slice)
-add_test(NAME TestOrPattern COMMAND test_or_pattern)
-add_test(NAME TestOrPatternGC COMMAND test_or_pattern_gc)
-add_test(NAME TestSeqDestructure COMMAND test_seq_destructure)
-add_test(NAME TestListPattern COMMAND test_list_pattern)
-add_test(NAME TestListPatternGC COMMAND test_list_pattern_gc)
-add_test(NAME TestAtBinding COMMAND test_at_binding)
-add_test(NAME TestAtBindingGC COMMAND test_at_binding_gc)
+
+# Register each GTest case as its own CTest test so `ctest -j` parallelizes
+# within a binary, not just across binaries. The per-target prefix keeps names
+# unique: the *_gc targets recompile the same sources, so their Suite.Case
+# names would otherwise collide.
+set(LOXPP_GTEST_TARGETS
+    test_scanner test_parser_vm test_parser_bytecode test_table test_allocator
+    test_local_variables test_control_flow test_vm_runtime test_closures
+    test_stress_gc test_gc_regression test_inheritance test_list test_list_gc
+    test_map test_map_gc test_var_destructure test_enum test_enum_gc
+    test_class_pattern test_class_pattern_gc test_match_expr test_slice
+    test_or_pattern test_or_pattern_gc test_seq_destructure test_list_pattern
+    test_list_pattern_gc test_at_binding test_at_binding_gc)
+foreach(t IN LISTS LOXPP_GTEST_TARGETS)
+    gtest_discover_tests(${t} TEST_PREFIX "${t}.")
+endforeach()

--- a/test/test_parser_bytecode.cpp
+++ b/test/test_parser_bytecode.cpp
@@ -230,7 +230,7 @@ TEST_F(ParserBytecodeTest, Arithmetic_Modulo) {
 class SequenceBytecodeTest : public ::testing::Test {};
 
 // `2 in [1, 2, 3]`
-// Chunk::addConstant does an O(N) dedup scan (see src/chunk.cpp), so the
+// Compiler::makeConstant dedups via a hash index (see src/compiler.cpp), so the
 // second occurrence of 2.0 (inside the list literal) reuses slot 0 instead
 // of allocating a new slot.
 // Slot layout: 0='2', 1='1', 2='3'


### PR DESCRIPTION
## Why

`ctest` wall-clock was dominated by `test_vm_runtime` — ~15s, almost entirely one case, `CompileErrorTest.TooManyConstants`, which compiles 65,536 numeric literals. `ctest -j` already parallelizes across the ~30 test binaries, so that one single-threaded compile was the floor.

## Root cause (two independent O(N²) costs in compilation)

The test hits the constant limit on the *last* statement → compile error → **no VM execution**, so the 15s is pure compilation. Bisecting by scaling N on a binary matching the test config found:

1. **`Compiler::number()` — dominant.** `std::stod(m_parser->m_previous.lexeme.data(), nullptr)`: `lexeme` is a `string_view` into the source and is **not NUL-terminated** at the token's end; `std::stod` has no `const char*` overload, so this constructed a `std::string` scanning to the **end of the whole source** on every literal → O(source length) per number.
2. **`Chunk::addConstant` — secondary.** Linear scan over all prior constants on every insert → O(N²) (~2.1B `Value` comparisons).

Both must be fixed — with `stod` linear, the dedup scan becomes the new bottleneck.

## Changes

- **`perf(compiler)`: parse number literals from a bounded lexeme** — construct the `std::string` from the `string_view` so the parse is bounded to the token.
- **`perf(compiler)`: dedup constants with a hash index, not a linear scan** — move dedup into the per-function `Compiler` (`m_constantIndex`, O(1) amortized); `Chunk::addConstant` becomes a plain bounded append. Dedup is a compile-time concern, so the index never reaches the runtime `Chunk` (no added GC roots / per-chunk memory). Adds `ValueHash` to the value system: a general-purpose `Value` hash consistent with `operator==` (`Obj*` by pointer identity, unlike the string-only `hashValue`), written via `is<T>`/`as<T>` so it carries over to the in-flight NaN-tagged `Value` unchanged.
- **`test`: discover gtest cases individually** via `gtest_discover_tests`, so `ctest -j` parallelizes per-case, not just per-binary. Per-target prefix keeps names unique (the `_gc` targets recompile the same sources). `test_main` stays a plain `add_test`.

Slot-assignment order and the `COMPILE_ERROR` on pool exhaustion are preserved.

## Results (verified, debug = ASan)

| | Before | After |
|---|---|---|
| `TooManyConstants` (debug) | 16.3s | 0.43s |
| Full suite (debug) | ~18.5s | 2.73s |
| Full suite (release) | — | 0.94s |
| CTest entries | ~30 | 716 |

All 715 tests pass on both `debug` and `release` presets; clang-format clean; clang-tidy reports no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
