### PR TITLE
perf: bitmask hash-table probe instead of modulo

### DIFF
--- a/src/core_hash_map.h
+++ b/src/core_hash_map.h
@@ -23,7 +23,9 @@ class CoreHashMap {
     // Works for both Entry* and const Entry* by template deduction on E.
     template <typename E, typename KeyMatch>
     static E* findSlotIn(E* data, int cap, uint32_t hash, KeyMatch match) {
-        uint32_t idx = hash % static_cast<uint32_t>(cap);
+        // cap is always a power of two (grow() doubles from 8), so the index
+        // reduction is a bitmask rather than a per-probe hardware divide.
+        uint32_t idx = hash & (static_cast<uint32_t>(cap) - 1);
         E* tombstone = nullptr;
         for (;;) {
             E* e = &data[idx];
@@ -37,7 +39,7 @@ class CoreHashMap {
             } else if (match(*e)) {
                 return e;
             }
-            idx = (idx + 1) % static_cast<uint32_t>(cap);
+            idx = (idx + 1) & (static_cast<uint32_t>(cap) - 1);
         }
     }
 

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -35,7 +35,8 @@ ObjString* Table::findString(const char* chars, int length,
         return nullptr;
     }
     int cap = m_map.capacity();
-    uint32_t index = hash % static_cast<uint32_t>(cap);
+    // cap is a power of two (see CoreHashMap::grow): modulo reduces to a mask.
+    uint32_t index = hash & (static_cast<uint32_t>(cap) - 1);
     for (;;) {
         const Entry* entry = m_map.entryAt(index);
         if (TablePolicy::isEmpty(*entry)) {
@@ -47,7 +48,7 @@ ObjString* Table::findString(const char* chars, int length,
             memcmp(entry->key->chars.data(), chars, length) == 0) {
             return entry->key;
         }
-        index = (index + 1) % static_cast<uint32_t>(cap);
+        index = (index + 1) & (static_cast<uint32_t>(cap) - 1);
     }
 }
 


### PR DESCRIPTION
Replaces the modulo bucket-index reduction in the hash table with a bitmask — the optimization from **Crafting Interpreters chapter 30 ("Optimization")**.

## Change

`CoreHashMap::findSlotIn` (used by globals, string interning, and `ObjMap`) and `Table::findString` computed the bucket index with `hash % cap`, which emits a hardware integer divide (~20–30 cycles) on every probe step. Capacity is always a power of two — `grow()` doubles from 8 — so `hash & (cap - 1)` is exactly equivalent and reduces to a single `AND`.

```diff
-        uint32_t idx = hash % static_cast<uint32_t>(cap);
+        uint32_t idx = hash & (static_cast<uint32_t>(cap) - 1);
```

A short comment records the power-of-two invariant at each site.

## Why it matters

Found while profiling the recursive `fib` benchmark: `OP_GET_GLOBAL` does a globals-table lookup on **every** call (~8.3% of dispatched opcodes; ~30M lookups for `fibonacci(35)`), so the per-probe divide is on the hot path.

## Measurement

`fibonacci(35)`, Release build (`-O3`), loxpp-dev-env container:

| | fib(35) |
|---|---|
| before (`%`) | ~1.12 s |
| after (`&`) | ~1.02 s |

**~9% faster.** For reference, stock clox (same program, also NaN-boxed) runs it in ~0.81 s; this closes about a third of that gap.

## Testing

- Full suite green under the `debug` preset (ASan + UBSan): **31/31 tests pass**, including the GC-stress and map/table suites.
- The change is representation-agnostic (hash map only), so it applies equally to the NaN-tagging and `std::variant` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
